### PR TITLE
fix: [CO-183] service-discover status and logging

### DIFF
--- a/src/bin/zmcontrol
+++ b/src/bin/zmcontrol
@@ -340,6 +340,7 @@ sub doStartup {
         {
             print "\tStarting $_ webapp...";
         }
+        elsif ( $_ eq "service-discover" ){ next; }
         else {
             print "\tStarting $_...";
         }

--- a/src/bin/zmcontrol
+++ b/src/bin/zmcontrol
@@ -230,6 +230,9 @@ sub doStatus {
             my $bit = "$_ webapp";
             $stat = sprintf "\t%-20s %10s\n", $bit,
               ($rc) ? "Stopped" : "Running";
+        }elsif ( $_ eq "service-discover" ){
+            my $ret = `systemctl is-active service-discover.service >/dev/null 2>&1 && echo 1 || echo 0`;
+            $stat = sprintf "\t%-20s %10s\n", $_, ($rc) ? "Running" : "Stopped";
         }
         else {
             $stat = sprintf "\t%-20s %10s\n", $_, ($rc) ? "Stopped" : "Running";

--- a/src/bin/zmcontrol
+++ b/src/bin/zmcontrol
@@ -231,8 +231,8 @@ sub doStatus {
             $stat = sprintf "\t%-20s %10s\n", $bit,
               ($rc) ? "Stopped" : "Running";
         }elsif ( $_ eq "service-discover" ){
-            my $ret = `systemctl is-active service-discover.service >/dev/null 2>&1 && echo 1 || echo 0`;
-            $stat = sprintf "\t%-20s %10s\n", $_, ($ret) ? "Running" : "Stopped";
+            $rc = system("systemctl is-active service-discover.service >/dev/null 2>&1");
+            $stat = sprintf "\t%-20s %10s\n", $_, ($rc) ? "Stopped" : "Running";
         }
         else {
             $stat = sprintf "\t%-20s %10s\n", $_, ($rc) ? "Stopped" : "Running";

--- a/src/bin/zmcontrol
+++ b/src/bin/zmcontrol
@@ -232,7 +232,7 @@ sub doStatus {
               ($rc) ? "Stopped" : "Running";
         }elsif ( $_ eq "service-discover" ){
             my $ret = `systemctl is-active service-discover.service >/dev/null 2>&1 && echo 1 || echo 0`;
-            $stat = sprintf "\t%-20s %10s\n", $_, ($rc) ? "Running" : "Stopped";
+            $stat = sprintf "\t%-20s %10s\n", $_, ($ret) ? "Running" : "Stopped";
         }
         else {
             $stat = sprintf "\t%-20s %10s\n", $_, ($rc) ? "Stopped" : "Running";


### PR DESCRIPTION
- fix: [CO-183] service-discover status in the status
     provide service discover running status in status
- fix: skip service-discover while start
    prevent reporting error for service-discover service
    while starting services.[being a systemd service]
