### PR TITLE
chore: [CO-298] update ProxyConfGen executable path

### DIFF
--- a/src/libexec/zmproxyconfgen
+++ b/src/libexec/zmproxyconfgen
@@ -6,4 +6,4 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-exec $(dirname $0)/../bin/zmjava com.zimbra.cs.util.ProxyConfGen "$@"
+exec $(dirname $0)/../bin/zmjava com.zimbra.cs.util.proxyconfgen.ProxyConfGen "$@"


### PR DESCRIPTION
update the executable path for ProxyConfGen util according to the new changes made in https://github.com/Zextras/carbonio-mailbox/pull/45