### PR TITLE
fix(CO-309): zmcontrol -v shows all info now

### DIFF
--- a/src/bin/zmcontrol
+++ b/src/bin/zmcontrol
@@ -580,6 +580,8 @@ sub displayVersion {
 }
 
 sub displayPackagesVersion {
+    my $zal_path =     "/opt/zextras/lib/ext/carbonio/zal.jar";
+    my $zextras_path = "/opt/zextras/lib/ext/carbonio/carbonio.jar";
     my $release = qx(cat /opt/zextras/.version);
     chomp $release;
     my $distro = `cat /etc/os-release | grep ID= | head -n1 | cut -f2 -d'='`;
@@ -589,10 +591,13 @@ sub displayPackagesVersion {
         $packages = `dpkg-query -W -f'${Package} ${Version}\n' carbonio*`;
     }
     if ($distro eq "rhel" or $distro eq "rocky" or $distro eq "centos") {
-         # TODO get package list for rpm/dhf based distros
+        $packages = `dnf list installed | grep carbonio* | awk -F' ' '{{ print $1 " " $2 }}'`
     }
 
     my $output = "Carbonio Release $release";
+    if (-e $zal_path and -e $zextras_path) {
+        $output .= "\n" . "Advanced version installed."
+    }
     if (! ($packages eq "")) {
         $output .= "\n" . "Installed packages: " . "\n";
     }

--- a/src/bin/zmcontrol
+++ b/src/bin/zmcontrol
@@ -144,7 +144,7 @@ my %REMOTECOMMANDS = (
 
 $| = 1;
 
-unless ( getopts( 'vhH:', \%GlobalOpts ) ) { usage(); }
+unless ( getopts( 'VvhH:', \%GlobalOpts ) ) { usage(); }
 
 if ( !$GlobalOpts{H} ) {
     $GlobalOpts{H} = $localHostName;
@@ -153,6 +153,7 @@ if ( !$GlobalOpts{H} ) {
 
 if ( $GlobalOpts{h} ) { usage(); }
 if ( $GlobalOpts{v} ) { displayVersion(); exit 0; }
+if ( $GlobalOpts{V} ) { displayPackagesVersion(); exit 0; }
 
 # Commands: start, stop, restart and status
 my $command = $ARGV[0];
@@ -559,12 +560,44 @@ sub getHostName {
 }
 
 sub displayVersion {
+    my $zal_path =     "/opt/zextras/lib/ext/carbonio/zal.jar";
+    my $zextras_path = "/opt/zextras/lib/ext/carbonio/carbonio.jar";
+
+    my $additional_zal_version = "";
+    if (-e $zal_path and -e $zextras_path) {
+         $additional_zal_version = `carbonio core getVersion`;
+        chomp $additional_zal_version;
+    }
+
     my $release = qx(cat /opt/zextras/.version);
     chomp $release;
-    my $string = "Release $release";
-    $string .=
-      ( ( -f "/opt/zextras/bin/zmbackupquery" ) ? "" : " Community Edition" );
-    print "$string.\n";
+
+    my $output = "Carbonio Release $release";
+    if (! ($additional_zal_version eq "")) {
+        $output .= "\nAdvance module version:\n" . $additional_zal_version
+    }
+    print "$output.\n";
+}
+
+sub displayPackagesVersion {
+    my $release = qx(cat /opt/zextras/.version);
+    chomp $release;
+    my $distro = `cat /etc/os-release | grep ID= | head -n1 | cut -f2 -d'='`;
+
+    my $packages = "";
+    if ($distro eq "ubuntu") {
+        $packages = `dpkg-query -W -f'${Package} ${Version}\n' carbonio*`;
+    }
+    if ($distro eq "rhel" or $distro eq "rocky" or $distro eq "centos") {
+         # TODO get package list for rpm/dhf based distros
+    }
+
+    my $output = "Carbonio Release $release";
+    if (! ($packages eq "")) {
+        $output .= "\n" . "Installed packages: " . "\n";
+    }
+
+    print "$output.\n"
 }
 
 sub checkAvailableSpace {

--- a/src/bin/zmcontrol
+++ b/src/bin/zmcontrol
@@ -6,6 +6,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
 use strict;
+use warnings;
 
 my $id = qx(id -u -n);
 chomp $id;
@@ -141,6 +142,9 @@ my %REMOTECOMMANDS = (
     #"maintenance" => "maintenance",
     "status" => "status",
 );
+
+my $zal_path =     "/opt/zextras/lib/ext/carbonio/zal.jar";
+my $zextras_path = "/opt/zextras/lib/ext/carbonio/carbonio.jar";
 
 $| = 1;
 
@@ -560,12 +564,9 @@ sub getHostName {
 }
 
 sub displayVersion {
-    my $zal_path =     "/opt/zextras/lib/ext/carbonio/zal.jar";
-    my $zextras_path = "/opt/zextras/lib/ext/carbonio/carbonio.jar";
-
     my $additional_zal_version = "";
     if (-e $zal_path and -e $zextras_path) {
-         $additional_zal_version = `carbonio core getVersion`;
+        $additional_zal_version = `carbonio core getVersion`;
         chomp $additional_zal_version;
     }
 
@@ -580,29 +581,28 @@ sub displayVersion {
 }
 
 sub displayPackagesVersion {
-    my $zal_path =     "/opt/zextras/lib/ext/carbonio/zal.jar";
-    my $zextras_path = "/opt/zextras/lib/ext/carbonio/carbonio.jar";
     my $release = qx(cat /opt/zextras/.version);
     chomp $release;
     my $distro = `cat /etc/os-release | grep ID= | head -n1 | cut -f2 -d'='`;
+    chomp $distro;
 
     my $packages = "";
     if ($distro eq "ubuntu") {
-        $packages = `dpkg-query -W -f'${Package} ${Version}\n' carbonio*`;
+        $packages = qx'dpkg-query -W -f\'${Package} ${Version}\n\' carbonio\*';
     }
-    if ($distro eq "rhel" or $distro eq "rocky" or $distro eq "centos") {
-        $packages = `dnf list installed | grep carbonio* | awk -F' ' '{{ print $1 " " $2 }}'`
+    if ($distro eq 'rhel' or $distro eq 'rocky' or $distro eq 'centos') {
+        $packages = qx'dnf list installed | grep carbonio* | awk -F\' \' \'{{ print $1 " " $2 }}\''
     }
 
-    my $output = "Carbonio Release $release";
+    my $output = "Carbonio Release $release\n";
     if (-e $zal_path and -e $zextras_path) {
-        $output .= "\n" . "Advanced version installed."
+        $output .= "Advanced version installed"
     }
     if (! ($packages eq "")) {
-        $output .= "\n" . "Installed packages: " . "\n";
+        $output .= "Installed packages:\n" . "$packages";
     }
 
-    print "$output.\n"
+    print "$output"
 }
 
 sub checkAvailableSpace {

--- a/src/bin/zmcontrol
+++ b/src/bin/zmcontrol
@@ -6,7 +6,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
 use strict;
-use warnings;
 
 my $id = qx(id -u -n);
 chomp $id;

--- a/src/bin/zmcontrol
+++ b/src/bin/zmcontrol
@@ -576,7 +576,7 @@ sub displayVersion {
     if (! ($additional_zal_version eq "")) {
         $output .= "\nAdvanced module version:\n" . $additional_zal_version
     }
-    print "$output.\n";
+    print "$output\n";
 }
 
 sub displayPackagesVersion {
@@ -589,8 +589,8 @@ sub displayPackagesVersion {
     if ($distro eq "ubuntu") {
         $packages = qx'dpkg-query -W -f\'${Package} ${Version}\n\' carbonio\*';
     }
-    if ($distro eq 'rhel' or $distro eq 'rocky' or $distro eq 'centos') {
-        $packages = qx'dnf list installed | grep carbonio* | awk -F\' \' \'{{ print $1 " " $2 }}\''
+    if ($distro eq '"rhel"' or $distro eq '"rocky"' or $distro eq '"centos"') {
+        $packages = qx'dnf list installed 2>/dev/null | grep carbonio* | awk -F\' \' \'{{ print $1 " " $2 }}\''
     }
 
     my $output = "Carbonio Release $release\n";
@@ -598,7 +598,9 @@ sub displayPackagesVersion {
         $output .= "Advanced version installed"
     }
     if (! ($packages eq "")) {
-        $output .= "Installed packages:\n" . "$packages";
+        $output .= "\nInstalled packages:\n" . "$packages";
+    } else {
+        $output .= "\n";
     }
 
     print "$output"

--- a/src/bin/zmcontrol
+++ b/src/bin/zmcontrol
@@ -666,6 +666,7 @@ sub usage {
     print "$0 [-v -h -H <host>] command [args]\n";
     print "\n";
     print "\t-v:	display version\n";
+    print "\t-V:    display advanced version information\n";
     print "\t-h:	print usage statement\n";
     print "\t-H:	Host name (localhost)\n";
     print "\n";


### PR DESCRIPTION
* Add new command (`-V` that prints out `carbonio*` packages installed on the machine and its version)

Tested locally