### PR TITLE
bugfix: use of absolute zmshutil path to avoid potential issues

### DIFF
--- a/src/bin/antispam-mysql
+++ b/src/bin/antispam-mysql
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
 if [ x"${antispam_mysql_host}" = x$(zmhostname) -o x"${antispam_mysql_host}" = "xlocalhost" -o x"${antispam_mysql_host}" = "x127.0.0.1" -o x"${antispam_mysql_host}" = "x::1" ]; then

--- a/src/bin/antispam-mysql.server
+++ b/src/bin/antispam-mysql.server
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
 if [ x$(whoami) != "x${zimbra_user}" ]; then

--- a/src/bin/antispam-mysqladmin
+++ b/src/bin/antispam-mysqladmin
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
 if [ "x127.0.0.1" != x"${antispam_mysql_host}" -a x"${zimbra_server_hostname}" != x"${antispam_mysql_host}" -a "xlocalhost" != x"${antispam_mysql_host}" ]; then

--- a/src/bin/mysql
+++ b/src/bin/mysql
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
 exec /opt/zextras/common/bin/mysql -S ${mysql_socket} \

--- a/src/bin/mysql.server
+++ b/src/bin/mysql.server
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
 if [ x$(whoami) != "x${zimbra_user}" ]; then

--- a/src/bin/mysqladmin
+++ b/src/bin/mysqladmin
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
 exec /opt/zextras/common/bin/mysqladmin -S ${mysql_socket} -u root --password=${mysql_root_password} "$@"

--- a/src/bin/postfix
+++ b/src/bin/postfix
@@ -7,7 +7,7 @@
 
 progdir=$(dirname $0)
 
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 
 if [ ! -x /opt/zextras/common/sbin/postfix ]; then
   echo "Error: postfix not installed"

--- a/src/bin/zmamavisdctl
+++ b/src/bin/zmamavisdctl
@@ -14,7 +14,7 @@ if [ ! -x "/opt/zextras/common/sbin/amavisd" ]; then
   exit 0
 fi
 
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
 if [ ! -d "/opt/zextras/data/amavisd/.spamassassin" ]; then

--- a/src/bin/zmantispamdbpasswd
+++ b/src/bin/zmantispamdbpasswd
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
 antispam_mysql_enabled=$(echo ${antispam_mysql_enabled} | tr [:upper:] [:lower:])

--- a/src/bin/zmauditswatchctl
+++ b/src/bin/zmauditswatchctl
@@ -10,7 +10,7 @@ if [ x$(whoami) != xzextras ]; then
   exit 1
 fi
 
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
 configfile=/opt/zextras/conf/auditswatchrc

--- a/src/bin/zmcbpolicydctl
+++ b/src/bin/zmcbpolicydctl
@@ -10,7 +10,7 @@ if [ x$(whoami) != xzextras ]; then
   exit 1
 fi
 
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
 pidfile=${cbpolicyd_pid_file:=${zimbra_log_directory}/cbpolicyd.pid}

--- a/src/bin/zmclamdctl
+++ b/src/bin/zmclamdctl
@@ -14,7 +14,7 @@ if [ ! -x "/opt/zextras/common/sbin/clamd" ]; then
   exit 0
 fi
 
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
 pidfile=${zimbra_log_directory}/clamd.pid

--- a/src/bin/zmconfigdctl
+++ b/src/bin/zmconfigdctl
@@ -10,7 +10,7 @@ if [ x$(whoami) != xzextras ]; then
   exit 1
 fi
 
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
 # These variables are not set if run via cron.  Make sure they are set prior to execution

--- a/src/bin/zmfreshclamctl
+++ b/src/bin/zmfreshclamctl
@@ -14,7 +14,7 @@ if [ ! -x "/opt/zextras/common/bin/freshclam" ]; then
   exit 0
 fi
 
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
 fpidfile=${zimbra_log_directory}/freshclam.pid

--- a/src/bin/zminnotop
+++ b/src/bin/zminnotop
@@ -32,7 +32,7 @@ if [ x"$1" = "x-h" ]; then
   exit 0
 fi
 
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
 if [ -x "/opt/zextras/common/bin/innotop" ]; then

--- a/src/bin/zmjava
+++ b/src/bin/zmjava
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
 # Much faster; just call zmlocalconfig once
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars -f
 
 if [ -d ${zimbra_java_home}/jre ]; then

--- a/src/bin/zmjavaext
+++ b/src/bin/zmjavaext
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
 # Much faster; just call zmlocalconfig once
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars -f
 
 if [ -d ${zimbra_java_home}/jre ]; then

--- a/src/bin/zmlogswatchctl
+++ b/src/bin/zmlogswatchctl
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
 configfile=/opt/zextras/conf/logswatchrc

--- a/src/bin/zmmailboxdctl
+++ b/src/bin/zmmailboxdctl
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
 if [ ! -d ${mailboxd_directory} ]; then

--- a/src/bin/zmmemcachedctl
+++ b/src/bin/zmmemcachedctl
@@ -10,7 +10,7 @@ if [ x$(whoami) != xzextras ]; then
   exit 1
 fi
 
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
 servicename=memcached

--- a/src/bin/zmmilterctl
+++ b/src/bin/zmmilterctl
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
 libjars=/opt/zextras/lib/jars

--- a/src/bin/zmmtactl
+++ b/src/bin/zmmtactl
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
 BASE=/opt/zextras

--- a/src/bin/zmmypasswd
+++ b/src/bin/zmmypasswd
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
 #

--- a/src/bin/zmmytop
+++ b/src/bin/zmmytop
@@ -31,7 +31,7 @@ if [ x"$1" = "x-h" ]; then
   exit 0
 fi
 
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
 if [ -x "/opt/zextras/common/bin/mytop" ]; then

--- a/src/bin/zmopendkimctl
+++ b/src/bin/zmopendkimctl
@@ -14,7 +14,7 @@ if [ ! -x "/opt/zextras/common/sbin/opendkim" ]; then
         exit 0
 fi
 
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
 PID=""

--- a/src/bin/zmplayredo
+++ b/src/bin/zmplayredo
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
 u=$(id -un)

--- a/src/bin/zmproxyctl
+++ b/src/bin/zmproxyctl
@@ -10,7 +10,7 @@ if [ x$(whoami) != xzextras ]; then
   exit 1
 fi
 
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
 servicename=proxy

--- a/src/bin/zmsaslauthdctl
+++ b/src/bin/zmsaslauthdctl
@@ -10,7 +10,7 @@ if [ x$(whoami) != xzextras ]; then
   exit 1
 fi
 
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
 pid=""

--- a/src/bin/zmstat-chart
+++ b/src/bin/zmstat-chart
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
 u=$(id -un)

--- a/src/bin/zmstorectl
+++ b/src/bin/zmstorectl
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
 MYSQL="/opt/zextras/bin/mysql -u zextras --password=${zimbra_mysql_password}"

--- a/src/bin/zmswatchctl
+++ b/src/bin/zmswatchctl
@@ -10,7 +10,7 @@ if [ x$(whoami) != xzextras ]; then
   exit 1
 fi
 
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
 configfile=/opt/zextras/conf/swatchrc

--- a/src/bin/zmtrainsa
+++ b/src/bin/zmtrainsa
@@ -98,7 +98,7 @@ if [ ! -x "/opt/zextras/common/sbin/amavisd" ]; then
   exit 1
 fi
 
-source $(dirname $0)/zmshutil || exit 1
+source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
 amavis_dspam_enabled=$(/opt/zextras/bin/zmprov -l gs ${zimbra_server_hostname} zimbraAmavisDSPAMEnabled | grep zimbraAmavisDSPAMEnabled: | awk '{print $2}')


### PR DESCRIPTION
This fix, above all, issues with the `zmloggerctl` and `zmamavidctl` execution