### PR TITLE
fix: zmdailyreport: adjust pflogsumm name

### DIFF
--- a/src/libexec/zmdailyreport
+++ b/src/libexec/zmdailyreport
@@ -116,7 +116,7 @@ if (fork()) {
 	$user_limit = 50 if $user_limit !~ /^\d+/;
 	$host_limit = 50 if $host_limit !~ /^\d+/;
     @ARGV = ('-u', $user_limit, '-h', $host_limit);
-    do '/opt/zextras/common/bin/pflogsumm.pl';
+    do '/opt/zextras/common/bin/pflogsumm';
     close(STDOUT);
 }
 


### PR DESCRIPTION
this fix a bug that prevent `/opt/zextras/libexec/zmdailyreport` execution