### PR TITLE
chore: avoid kill -9 to gracefully kill the processes

### DIFF
--- a/src/bin/jetty
+++ b/src/bin/jetty
@@ -260,7 +260,7 @@ stop)
   echo "Shutting down Jetty: $PID"
   kill $PID 2>/dev/null
   sleep 2
-  kill -9 $PID 2>/dev/null
+  kill $PID 2>/dev/null
   rm -f $JETTY_PID
   echo "STOPPED $(date)" >>$JETTY_CONSOLE
   ;;

--- a/src/bin/ldap
+++ b/src/bin/ldap
@@ -56,7 +56,7 @@ stop() {
     echo "slapd not running"
     exit 1
   else
-    kill -TERM $PID
+    kill $PID
   fi
 }
 

--- a/src/bin/ldap.production
+++ b/src/bin/ldap.production
@@ -120,7 +120,7 @@ stop() {
     exit 0
   fi
   echo -n "Killing slapd with pid $PID"
-  kill -TERM $PID
+  kill $PID
   for ((i = 0; i < 1500; i++)); do
     if ! kill -0 $PID 2>/dev/null; then
       echo " done."
@@ -131,7 +131,7 @@ stop() {
     fi
     sleep 1
   done
-  if kill -TERM $PID; then
+  if kill $PID; then
     echo " gave up waiting!"
     exit 1
   fi

--- a/src/bin/zmamavisdctl
+++ b/src/bin/zmamavisdctl
@@ -146,7 +146,7 @@ case "$1" in
   if [ $RUNNING = 0 ]; then
     echo "amavisd is not running."
   else
-    kill -TERM $PID 2>/dev/null
+    kill $PID 2>/dev/null
     for ((i = 0; i < 300; i++)); do
       sleep 5
       kill -0 $PID 2>/dev/null
@@ -154,7 +154,7 @@ case "$1" in
         break
       fi
     done
-    kill -TERM $PID 2>/dev/null
+    kill $PID 2>/dev/null
     if [ $? != 0 ]; then
       echo " done."
     else
@@ -167,7 +167,7 @@ case "$1" in
   if [ $MCRUNNING = 0 ]; then
     echo "amavisd-mc is not running."
   else
-    kill -TERM $MCPID 2>/dev/null
+    kill $MCPID 2>/dev/null
     for ((i = 0; i < 300; i++)); do
       sleep 5
       kill -0 $MCPID 2>/dev/null
@@ -175,7 +175,7 @@ case "$1" in
         break
       fi
     done
-    kill -TERM $MCPID 2>/dev/null
+    kill $MCPID 2>/dev/null
     if [ $? != 0 ]; then
       echo " done."
     else

--- a/src/bin/zmcbpolicydctl
+++ b/src/bin/zmcbpolicydctl
@@ -101,7 +101,7 @@ case "$1" in
     echo "policyd is not running."
     exit 0
   else
-    kill -TERM $PID 2>/dev/null
+    kill $PID 2>/dev/null
     for ((i = 0; i < 300; i++)); do
       sleep 5
       kill -0 $PID 2>/dev/null
@@ -110,7 +110,7 @@ case "$1" in
         exit 0
       fi
     done
-    kill -TERM $PID 2>/dev/null
+    kill $PID 2>/dev/null
     if [ $? = 0 ]; then
       echo " failed to stop $PID"
       exit 1

--- a/src/bin/zmclamdctl
+++ b/src/bin/zmclamdctl
@@ -94,9 +94,9 @@ case "$1" in
 'kill')
   if [ -f /opt/zextras/log/clamd.pid ]; then
     cpid=$(cat /opt/zextras/log/clamd.pid)
-    kill -9 "$cpid" 2>/dev/null
+    kill "$cpid" 2>/dev/null
   fi
-  pskillall -9 /opt/zextras/common/sbin/clamd
+  pskillall /opt/zextras/common/sbin/clamd
   exit 0
   ;;
 
@@ -107,7 +107,7 @@ case "$1" in
     echo "clamd is not running."
   else
     if [ x"$cpid" != "x" ]; then
-      kill -TERM "$cpid" 2>/dev/null
+      kill "$cpid" 2>/dev/null
     fi
     for ((i = 0; i < 30; i++)); do
       sleep 2

--- a/src/bin/zmconfigdctl
+++ b/src/bin/zmconfigdctl
@@ -66,7 +66,7 @@ startzmconfigd() {
     return
   fi
   if [ "x${pid}" != "x" ]; then
-    kill -9 ${pid}
+    kill ${pid}
   fi
   rm -rf ${pidfile}
   /opt/zextras/libexec/zmconfigd >/dev/null 2>&1 &

--- a/src/bin/zmfreshclamctl
+++ b/src/bin/zmfreshclamctl
@@ -81,9 +81,9 @@ case "$1" in
 'kill')
   if [ -f /opt/zextras/log/freshclam.pid ]; then
     cpid=$(cat /opt/zextras/log/freshclam.pid)
-    kill -9 "$cpid" 2>/dev/null
+    kill "$cpid" 2>/dev/null
   fi
-  pskillall -9 /opt/zextras/common/bin/freshclam
+  pskillall /opt/zextras/common/bin/freshclam
   exit 0
   ;;
 
@@ -94,7 +94,7 @@ case "$1" in
     echo "freshclam is not running."
   else
     if [ x"$fpid" != "x" ]; then
-      kill -9 "$fpid" 2>/dev/null
+      kill "$fpid" 2>/dev/null
       if [ $? = 0 ]; then
         echo "done."
       else

--- a/src/bin/zmmemcachedctl
+++ b/src/bin/zmmemcachedctl
@@ -89,7 +89,7 @@ stop)
         rm -rf ${pidfile}
         break
       fi
-      kill -9 $pid
+      kill $pid
       sleep 1
     done
   fi

--- a/src/bin/zmopendkimctl
+++ b/src/bin/zmopendkimctl
@@ -73,7 +73,7 @@ stop() {
                 exit 0
         else
                 echo -n "Stopping opendkim..."
-                kill -TERM $PID 2>/dev/null
+                kill $PID 2>/dev/null
                 for ((i = 0; i < 300; i++)); do
                         sleep 5
                         kill -0 $PID 2>/dev/null
@@ -82,7 +82,7 @@ stop() {
                                 exit 0
                         fi
                 done
-                kill -TERM $PID 2>/dev/null
+                kill $PID 2>/dev/null
                 if [ $? = 0 ]; then
                         echo " failed to stop $PID"
                         exit 1


### PR DESCRIPTION
This is meaningful in itself but also toward the not-so-distant systemd units. Having a `kill -9` has undesiderated effects on systemd evaluated EXIT_STATUS, resulting in an implict exit(1) on services stop.

Tested on both zmcontrol and systemd powered environments.

![image](https://user-images.githubusercontent.com/491117/219068095-2a7d6ed5-0b4f-416f-bc4c-aa155caf896d.png)
