### PR TITLE
feat: [CO-621] Add certbot certonly execution

### DIFF
--- a/src/libexec/certbot
+++ b/src/libexec/certbot
@@ -6,8 +6,9 @@ if [ "$(whoami)" != "zextras" ]; then
 fi
 
 certonly() {
-  certbot "${@}" --dry-run
+  if certbot "${@}" --dry-run; then
   certbot "${@}"
+  fi
 }
 
 ACTION="${1}"

--- a/src/libexec/certbot
+++ b/src/libexec/certbot
@@ -7,6 +7,7 @@ fi
 
 certonly() {
   certbot "${@}" --dry-run
+  certbot "${@}"
 }
 
 ACTION="${1}"

--- a/src/libexec/certbot
+++ b/src/libexec/certbot
@@ -7,7 +7,7 @@ fi
 
 certonly() {
   if certbot "${@}" --dry-run; then
-  certbot "${@}"
+    certbot "${@}"
   fi
 }
 


### PR DESCRIPTION
Now will actually trigger certonly command if dry-run was successful.

Related PR: https://github.com/Zextras/carbonio-mailbox/pull/175