### PR TITLE
feat: [CO-656] make zmantivirusctl handle also clamav only setup

### DIFF
--- a/src/bin/zmantivirusctl
+++ b/src/bin/zmantivirusctl
@@ -7,40 +7,47 @@
 
 SCRIPTS="zmamavisdctl zmclamdctl zmfreshclamctl"
 
-if [ ! -x "/opt/zextras/common/sbin/amavisd" ]; then
-  exit 0
+AMAVISD_EXECUTABLE=0
+if [ -x "/opt/zextras/common/sbin/amavisd" ]; then
+  AMAVISD_EXECUTABLE=1
 fi
 
 source /opt/zextras/.bashrc
 
 case "$1" in
 start)
-  if [ x$2 = "x" ]; then
+  if [ "$2" = "" ]; then
     /opt/zextras/libexec/configrewrite antivirus
   fi
   for i in $SCRIPTS; do
-    /opt/zextras/bin/$i start norewrite
+    if [ "$i" = "zmamavisdctl" ] && [ "$AMAVISD_EXECUTABLE" -ne 1 ]; then
+      continue
+    fi
+    /opt/zextras/bin/"$i" start norewrite
   done
   ;;
 stop)
   for i in $SCRIPTS; do
-    if [ $i = "zmclamdctl" ]; then
-      /opt/zextras/bin/$i stop
-    fi
-    if [ $i = "zmfreshclamctl" ]; then
-      /opt/zextras/bin/$i stop
+    if [ "$i" = "zmclamdctl" ] || [ "$i" = "zmfreshclamctl" ]; then
+      /opt/zextras/bin/"$i" stop
     fi
   done
   ;;
 reload | restart)
   for i in $SCRIPTS; do
-    /opt/zextras/bin/$i $1
+    if [ "$i" = "zmamavisdctl" ] && [ "$AMAVISD_EXECUTABLE" -ne 1 ]; then
+      continue
+    fi
+    /opt/zextras/bin/"$i" "$1"
   done
   ;;
 status)
   STATUS=0
   for i in $SCRIPTS; do
-    /opt/zextras/bin/$i status >/dev/null 2>&1
+    if [ "$i" = "zmamavisdctl" ] && [ "$AMAVISD_EXECUTABLE" -ne 1 ]; then
+      continue
+    fi
+    /opt/zextras/bin/"$i" status >/dev/null 2>&1
     R=$?
     if [ $R -ne "0" ]; then
       echo "$i is not running"

--- a/src/bin/zmantivirusctl
+++ b/src/bin/zmantivirusctl
@@ -28,9 +28,10 @@ start)
   ;;
 stop)
   for i in $SCRIPTS; do
-    if [ "$i" = "zmclamdctl" ] || [ "$i" = "zmfreshclamctl" ]; then
-      /opt/zextras/bin/"$i" stop
+    if [ "$i" = "zmamavisdctl" ] && [ "$AMAVISD_EXECUTABLE" -ne 1 ]; then
+      continue
     fi
+    /opt/zextras/bin/"$i" stop
   done
   ;;
 reload | restart)

--- a/src/bin/zmcontrol
+++ b/src/bin/zmcontrol
@@ -76,7 +76,7 @@ my %stoporder = (
 
 my %allservices = (
     "amavis"           => "/opt/zextras/bin/zmamavisdctl",
-    "antivirus"        => "/opt/zextras/bin/zmclamdctl",
+    "antivirus"        => "/opt/zextras/bin/zmantivirusctl",
     "antispam"         => "/opt/zextras/bin/zmantispamctl",
     "opendkim"         => "/opt/zextras/bin/zmopendkimctl",
     "mta"              => "/opt/zextras/bin/zmmtactl",

--- a/src/bin/zmcontrol
+++ b/src/bin/zmcontrol
@@ -76,7 +76,7 @@ my %stoporder = (
 
 my %allservices = (
     "amavis"           => "/opt/zextras/bin/zmamavisdctl",
-    "antivirus"        => "/opt/zextras/bin/zmantivirusctl",
+    "antivirus"        => "/opt/zextras/bin/zmclamdctl",
     "antispam"         => "/opt/zextras/bin/zmantispamctl",
     "opendkim"         => "/opt/zextras/bin/zmopendkimctl",
     "mta"              => "/opt/zextras/bin/zmmtactl",


### PR DESCRIPTION
**What has changed:**

- do not control and report amavisd status if component is missing in case of single server clamav setup
- correctly report antivirus running for clamav only setups
- prevent parameter expansion eveywhere

see CO-597 for context.