### PR TITLE
feat: [COR-913] deploy Carbonio Advanced CLI as indipendent jar

### DIFF
--- a/src/bin/carbonio
+++ b/src/bin/carbonio
@@ -16,15 +16,15 @@ source /opt/zextras/bin/zmshutil || exit 1
 
 zal_path="/opt/zextras/lib/ext/carbonio/zal.jar"
 zextras_path="/opt/zextras/lib/ext/carbonio/carbonio.jar"
-carbonio_jars="/opt/zextras/lib/jars/*"
+carbonio_cli_jars="/usr/bin/carbonio-advanced-cli/*"
 
 call_cli() {
   if [ ! -f "${zal_path}" ] || [ ! -f "${zextras_path}" ]; then
     exec /opt/zextras/bin/zmjava com.zimbra.cs.account.ProvUtil "$@"
   else
     exec /opt/zextras/bin/zmjava \
-      -cp "${carbonio_jars}:${zal_path}:${zextras_path}" \
-      -Xmx128m org.openzal.zal.tools.ConsoleBoot com.zextras.cli.AdvancedCLI \
+      -cp "${carbonio_cli_jars}" \
+      -Xmx128m com.zextras.cli.AdvancedCLI \
       --columns "$(tput cols)" \
       "$@"
   fi

--- a/src/bin/carbonio
+++ b/src/bin/carbonio
@@ -20,7 +20,9 @@ carbonio_cli_jars="/usr/bin/carbonio-advanced-cli/*"
 
 call_cli() {
   if [ ! -f "${zal_path}" ] || [ ! -f "${carbonio_path}" ]; then
-    exec /opt/zextras/bin/zmjava com.zimbra.cs.account.ProvUtil "$@"
+    exec /opt/zextras/bin/zmjava \
+      com.zimbra.cs.account.ProvUtil \
+      "$@"
   else
     exec /opt/zextras/bin/zmjava \
       -cp "${carbonio_cli_jars}" \

--- a/src/bin/carbonio
+++ b/src/bin/carbonio
@@ -15,11 +15,11 @@ fi
 source /opt/zextras/bin/zmshutil || exit 1
 
 zal_path="/opt/zextras/lib/ext/carbonio/zal.jar"
-zextras_path="/opt/zextras/lib/ext/carbonio/carbonio.jar"
+carbonio_path="/opt/zextras/lib/ext/carbonio/carbonio.jar"
 carbonio_cli_jars="/usr/bin/carbonio-advanced-cli/*"
 
 call_cli() {
-  if [ ! -f "${zal_path}" ] || [ ! -f "${zextras_path}" ]; then
+  if [ ! -f "${zal_path}" ] || [ ! -f "${carbonio_path}" ]; then
     exec /opt/zextras/bin/zmjava com.zimbra.cs.account.ProvUtil "$@"
   else
     exec /opt/zextras/bin/zmjava \

--- a/src/bin/carbonio
+++ b/src/bin/carbonio
@@ -16,7 +16,7 @@ source /opt/zextras/bin/zmshutil || exit 1
 
 zal_path="/opt/zextras/lib/ext/carbonio/zal.jar"
 carbonio_path="/opt/zextras/lib/ext/carbonio/carbonio.jar"
-carbonio_cli_jars="/usr/bin/carbonio-advanced-cli/*"
+carbonio_cli_jars="/usr/share/carbonio-advanced-cli/*"
 
 # check for tty presence and set TPUT usage accordingly
 {


### PR DESCRIPTION
Hi, 
as a step of the splitting project, we completed the issue related to the deployment of `carbon-advanced-cli` as a separate jar from `carbon-advanced`. This means that the entry point of the `carbonio` can directly execute the cli main with only it's own dependencies loaded in the `classpath`.
