### PR TITLE
fix: [IN-590] apply proper privileges for certbot folder

### DIFF
--- a/src/libexec/zmfixperms
+++ b/src/libexec/zmfixperms
@@ -92,6 +92,10 @@ for i in master.cf master.cf.in bysender bysender.lmdb tag_as_foreign.re tag_as_
   fi
 done
 
+if [ -d "/opt/zextras/common/certbot/etc/letsencrypt" ]; then
+  chown -R ${zextras_user}:${zextras_group} /opt/zextras/common/certbot/etc/letsencrypt
+fi
+
 if [ -f /opt/zextras/common/conf/main.cf ]; then
   chown -f ${root_user}:${root_group} /opt/zextras/common/conf/main.cf
 fi


### PR DESCRIPTION
early in the first steps of zmfixperm there's a `chown -R root:root /opt/zextras/common` that breaks carbonio-certbot and carbonio-core privileges checks.
At the end of carbonio-core postinst there a zmfixperms, so let's add another check on it, with the hope to deprecate the zmfixperms logic early