### PR TITLE
fix: nginx: don't use sudo but leverage the CAP_NET_BIND_SERVICE=+ep

### DIFF
--- a/src/bin/zmproxyctl
+++ b/src/bin/zmproxyctl
@@ -76,7 +76,7 @@ case "$1" in
       fi
     fi
 
-    sudo /opt/zextras/common/sbin/nginx -c ${configfile}
+    /opt/zextras/common/sbin/nginx -c ${configfile}
     for ((i = 0; i < 30; i++)); do
       checkrunning
       if [ $running = 1 ]; then
@@ -102,7 +102,7 @@ case "$1" in
       echo "${servicename} is not running."
       exit 0
     else
-      sudo /opt/zextras/common/sbin/nginx -c /opt/zextras/conf/nginx.conf -s stop
+      /opt/zextras/common/sbin/nginx -c /opt/zextras/conf/nginx.conf -s stop
       sleep 1
     fi
     if [ -s "${pidfile}" ]; then
@@ -121,7 +121,7 @@ case "$1" in
     checkrunning
     if [ $running = 1 ] && [ "$pid" != "" ]; then
       echo -n "Reloading ${servicename}..."
-      sudo /opt/zextras/common/sbin/nginx -c /opt/zextras/conf/nginx.conf -s reload
+      /opt/zextras/common/sbin/nginx -c /opt/zextras/conf/nginx.conf -s reload
       echo "done."
     fi
 


### PR DESCRIPTION
Capability for nginx to bind on privileged ports is provided by this line
https://github.com/zextras/carbonio-core-utils/blob/main/src/libexec/zmfixperms#L619