### PR TITLE
refactor: [CO-1046] embedded jetty

### DIFF
--- a/conf/zmconfigd.cf
+++ b/conf/zmconfigd.cf
@@ -329,7 +329,6 @@ SECTION mailbox
 	LOCAL zimbra_uid
 	LOCAL zimbra_gid
 	REWRITE conf/log4j.properties.in conf/log4j.properties
-	REWRITE mailboxd/etc/jetty.xml.in mailboxd/etc/jetty.xml
 	REWRITE conf/spnego_java_options.in conf/spnego_java_options
 	REWRITE mailboxd/modules/setuid.mod.in mailboxd/modules/setuid.mod
 	REWRITE mailboxd/start.d/setuid.ini.in mailboxd/start.d/setuid.ini	
@@ -339,7 +338,7 @@ SECTION mailbox
 	RESTART mailboxd
 
 SECTION service
-	REWRITE mailboxd/etc/service.web.xml.in mailboxd/webapps/service/WEB-INF/web.xml
+	REWRITE conf/web.xml.in conf/web.xml
 	RESTART mailboxd
 
 SECTION proxy

--- a/src/bin/zmjava
+++ b/src/bin/zmjava
@@ -30,7 +30,7 @@ if [ "${zimbra_zmjava_java_library_path}" = "" ]; then
 fi
 
 if [ "${zimbra_zmjava_java_ext_dirs}" = "" ]; then
-  zimbra_zmjava_java_ext_dirs=${JRE_EXT_DIR}:/opt/zextras/lib/jars:${ZIMBRA_EXT_DIR}
+  zimbra_zmjava_java_ext_dirs=${JRE_EXT_DIR}:/opt/zextras/mailbox/jars:${ZIMBRA_EXT_DIR}
 fi
 
 if [ -n "${EXT_JAR_PATH}" ]; then
@@ -42,5 +42,5 @@ exec "${zimbra_java_home}/bin/java" ${java_options} \
   -client ${zimbra_zmjava_options} \
   -Dzimbra.home=/opt/zextras \
   -Djava.library.path=${zimbra_zmjava_java_library_path} \
-  -classpath "${zimbra_zmjava_java_ext_dirs}:/opt/zextras/lib/jars/*:/opt/zextras/conf" \
+  -classpath "${zimbra_zmjava_java_ext_dirs}:/opt/zextras/lib/jars/*:/opt/zextras/mailbox/jars/*:/opt/zextras/conf" \
   "$@"

--- a/src/bin/zmjavaext
+++ b/src/bin/zmjavaext
@@ -30,7 +30,7 @@ if [ "${zimbra_zmjava_java_library_path}" = "" ]; then
 fi
 
 if [ "${zimbra_zmjava_java_ext_dirs}" = "" ]; then
-  zimbra_zmjava_java_ext_dirs=${JRE_EXT_DIR}:/opt/zextras/lib/jars:${ZIMBRA_EXT_DIR}
+  zimbra_zmjava_java_ext_dirs=${JRE_EXT_DIR}:/opt/zextras/mailbox/jars:${ZIMBRA_EXT_DIR}
 fi
 
 # shellcheck disable=SC2086

--- a/src/bin/zmlocalconfig
+++ b/src/bin/zmlocalconfig
@@ -16,7 +16,7 @@ umask 0027
 
 java="${ROOT}/common/bin/java"
 
-CP="${ROOT}/lib/jars/*"
+CP="${ROOT}/mailbox/jars/*"
 
 exec ${java} -client -cp "$CP" \
   -Djava.library.path=${ROOT}/lib -Dzimbra.home="${ROOT}" \

--- a/src/bin/zmmailboxdctl
+++ b/src/bin/zmmailboxdctl
@@ -83,15 +83,15 @@ case "$1" in
 
     # shellcheck disable=SC2086
     /opt/zextras/common/bin/java \
-                -Dfile.encoding=UTF-8 \
-                $mailboxd_java_options \
+      -Dfile.encoding=UTF-8 \
+      $mailboxd_java_options \
       -Xms${javaXms}m \
       -Xmx${javaXmx}m \
-                -Djava.io.tmpdir=/opt/zextras/mailboxd/work \
-                -Djava.library.path=/opt/zextras/lib \
-                -Dzimbra.config=/opt/zextras/conf/localconfig.xml \
-                -cp /opt/zextras/mailbox/jars/mailbox.jar:/opt/zextras/mailbox/jars/* \
-                com.zextras.mailbox.Mailbox >/dev/null 2>&1 &
+      -Djava.io.tmpdir=/opt/zextras/mailboxd/work \
+      -Djava.library.path=/opt/zextras/lib \
+      -Dzimbra.config=/opt/zextras/conf/localconfig.xml \
+      -cp /opt/zextras/mailbox/jars/mailbox.jar:/opt/zextras/mailbox/jars/* \
+      com.zextras.mailbox.Mailbox >/dev/null 2>&1 &
     rc=$?
     if [ $rc != 0 ]; then
       echo "failed."

--- a/src/bin/zmmailboxdctl
+++ b/src/bin/zmmailboxdctl
@@ -80,24 +80,18 @@ case "$1" in
     fi
 
     echo -n "Starting mailboxd..."
+
     # shellcheck disable=SC2086
     /opt/zextras/common/bin/java \
-      -Dfile.encoding=UTF-8 \
-      $mailboxd_java_options \
+                -Dfile.encoding=UTF-8 \
+                $mailboxd_java_options \
       -Xms${javaXms}m \
       -Xmx${javaXmx}m \
-      -Djava.io.tmpdir=/opt/zextras/mailboxd/work \
-      -Djava.library.path=/opt/zextras/lib \
-      -Dzimbra.config=/opt/zextras/conf/localconfig.xml \
-      --module-path /opt/zextras/mailboxd/common/endorsed \
-      -Djetty.base=/opt/zextras/mailboxd \
-      -Djetty.home=/opt/zextras/common/jetty_home \
-      -DSTART=/opt/zextras/mailboxd/etc/start.config \
-      -jar /opt/zextras/common/jetty_home/start.jar \
-      --module=zimbra,server,mail,servlet,servlets,jsp,jstl,jmx,resources,websocket,ext,plus,rewrite,continuation,webapp,setuid \
-      jetty.home=/opt/zextras/common/jetty_home \
-      jetty.base=/opt/zextras/mailboxd \
-      /opt/zextras/mailboxd/etc/jetty.xml >/dev/null 2>&1 &
+                -Djava.io.tmpdir=/opt/zextras/mailboxd/work \
+                -Djava.library.path=/opt/zextras/lib \
+                -Dzimbra.config=/opt/zextras/conf/localconfig.xml \
+                -cp /opt/zextras/mailbox/jars/mailbox.jar:/opt/zextras/mailbox/jars/* \
+                com.zextras.mailbox.Mailbox >/dev/null 2>&1 &
     rc=$?
     if [ $rc != 0 ]; then
       echo "failed."

--- a/src/bin/zmplayredo
+++ b/src/bin/zmplayredo
@@ -47,7 +47,7 @@ else
   #JRE_EXT_DIR=${zimbra_java_home}/lib/ext
 fi
 
-jardirs="${JRE_EXT_DIR}:/opt/zextras/mailboxd/lib/*:/opt/zextras/mailboxd/common/lib/*:/opt/zextras/lib/jars/*"
+jardirs="${JRE_EXT_DIR}:/opt/zextras/mailbox/jars/*:"
 if [ -e /opt/zextras/lib/ext-common ]; then
   jardirs="${jardirs}:/opt/zextras/lib/ext-common/*"
 fi
@@ -56,7 +56,6 @@ while IFS= read -r -d '' jd; do
     jardirs="${jardirs}:${jd}/*"
   fi
 done < <(find /opt/zextras/lib/ext -type d -print0)
-jardirs="${jardirs}:/opt/zextras/jetty/common/lib/*:/opt/zextras/jetty/webapps/service/WEB-INF/lib/*"
 
 #
 # Memory for use by JVM

--- a/src/bin/zmpython
+++ b/src/bin/zmpython
@@ -6,4 +6,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
 export TMP=/opt/zextras/data/tmp
-exec /opt/zextras/bin/zmjava -Djava.io.tmpdir=/opt/zextras/data/tmp -Dpython.cachedir.skip=true org.python.util.jython "$@"
+exec /opt/zextras/bin/zmjava \
+-classpath "/opt/zextras/jython/jars/*:/opt/zextras/mailbox/jars/*:/opt/zextras/conf" \
+-Djava.io.tmpdir=/opt/zextras/data/tmp -Dpython.cachedir.skip=true org.python.util.jython "$@"

--- a/src/libexec/zmfixperms
+++ b/src/libexec/zmfixperms
@@ -348,8 +348,8 @@ if [ -d /opt/zextras/lib ]; then
     chown ${root_user}:${root_group} "$i"
     chmod 755 "$i"
   done
-  if [ -d /opt/zextras/lib/jars ]; then
-    for i in /opt/zextras/lib/jars/*; do
+  if [ -d /opt/zextras/mailbox/jars ]; then
+    for i in /opt/zextras/mailbox/jars/*; do
       chown ${root_user}:${root_group} "$i"
       chmod 444 "$i"
     done

--- a/src/libexec/zmjsprecompile
+++ b/src/libexec/zmjsprecompile
@@ -13,7 +13,7 @@ fi
 zimbra_java_home=/opt/zextras/common/lib/jvm/java
 jspc_src_dir=/opt/zextras/mailboxd/webapps/zimbra
 jspc_build_dir=/opt/zextras/mailboxd/work/zimbra/jsp
-jspc_class_path="/opt/zextras/lib/jars/*:/opt/zextras/common/jetty_home/lib/*:/opt/zextras/common/jetty_home/lib/apache-jsp/*:/opt/zextras/common/jetty_home/lib/apache-jstl/*:/opt/zextras/lib/jars/*:/opt/zextras/jetty/lib/ext/*:/opt/zextras/jetty/lib/plus/*:/opt/zextras/jetty/lib/naming/*:/opt/zextras/lib/ext/*:/opt/zextras/jetty/common/lib/*:/opt/zextras/jetty/webapps/zimbra/WEB-INF/lib/*"
+jspc_class_path="/opt/zextras/mailbox/jars/*:/opt/zextras/common/jetty_home/lib/*:/opt/zextras/common/jetty_home/lib/apache-jsp/*:/opt/zextras/common/jetty_home/lib/apache-jstl/*:/opt/zextras/mailbox/jars/*:/opt/zextras/jetty/lib/ext/*:/opt/zextras/jetty/lib/plus/*:/opt/zextras/jetty/lib/naming/*:/opt/zextras/lib/ext/*:/opt/zextras/jetty/common/lib/*:/opt/zextras/jetty/webapps/zimbra/WEB-INF/lib/*"
 
 extensions="backup clamscanner network carbonio-license zimbrahsm zimbrasync"
 ext_dir="/opt/zextras/lib/ext-common"


### PR DESCRIPTION
## Changes
- point to new mailbox jars location in /opt/zextras/mailbox/jars
- zmmailboxdctl use zmmailboxdmgr. Java options are evaluated in binary file /usr/bin/carbonio-appserver (see: https://github.com/zextras/carbonio-mailbox/pull/490)