### PR TITLE
chore: move .pid files to /run/carbonio

### DIFF
--- a/conf/zmconfigd.cf
+++ b/conf/zmconfigd.cf
@@ -448,7 +448,6 @@ SECTION ldap
 
 SECTION cbpolicyd
 	REWRITE conf/cbpolicyd.conf.in conf/cbpolicyd.conf
-	LOCAL cbpolicyd_pid_file
 	LOCAL cbpolicyd_log_file
 	LOCAL cbpolicyd_db_file
 	VAR zimbraCBPolicydLogLevel

--- a/conf/zmlogrotate
+++ b/conf/zmlogrotate
@@ -58,7 +58,7 @@
     create 0660 zextras zextras
     dateext
     postrotate
-      kill -HUP `cat /opt/zextras/log/clamd.pid 2> /dev/null` 2> /dev/null || true
+      kill -HUP $(pidof /opt/zextras/common/sbin/clamd 2> /dev/null) 2> /dev/null || true
     endscript
     compress
     size 5000k
@@ -74,7 +74,7 @@
     create 0660 zextras zextras
     dateext
     postrotate
-      kill -HUP `cat /opt/zextras/log/freshclam.pid 2> /dev/null` 2> /dev/null || true
+      kill -HUP $(pidof /opt/zextras/common/bin/freshclam 2> /dev/null) 2> /dev/null || true
     endscript
     compress
     size 1000k
@@ -90,7 +90,7 @@
     create 0644 zextras zextras
     dateext
     postrotate
-      kill -USR1 `cat /opt/zextras/log/nginx.pid 2> /dev/null` 2> /dev/null || true
+      kill -USR1 $(pgrep -f '/opt/zextras/.*/nginx.*conf' 2> /dev/null) 2> /dev/null || true
     endscript
     rotate 7
     compress

--- a/src/bin/antispam-mysql
+++ b/src/bin/antispam-mysql
@@ -13,7 +13,7 @@ if [ "${antispam_mysql_host}" = "$(zmhostname)" ] ||
   [ "${antispam_mysql_host}" = "127.0.0.1" ] ||
   [ "${antispam_mysql_host}" = "::1" ]; then
   exec /opt/zextras/common/bin/mysql \
-    --socket="${antispam_mysql_socket}" \
+    --socket=/run/carbonio/antispam-mysql.sock \
     --user="${antispam_mysql_user}" \
     --password="${antispam_mysql_password}" "$@"
 else

--- a/src/bin/antispam-mysql.server
+++ b/src/bin/antispam-mysql.server
@@ -34,65 +34,36 @@ if [ ! -d "${zimbra_tmp_directory}/antispam-mysql" ]; then
   mkdir -p "${zimbra_tmp_directory}/antispam-mysql" >/dev/null 2>&1
 fi
 
-zmassert -d "${zimbra_tmp_directory}"
-zmassert -x /opt/zextras/common/bin/mysqld_safe
+assert -d "${zimbra_tmp_directory}"
+assert -x /opt/zextras/common/bin/mysqld_safe
 
-# innodb will open the database before binding and writing out the pid
-# potentially corrupting the files
-# prevent multiple init scripts from running at the same time.
-initlockfile=${zimbra_tmp_directory}/antispam-mysql/antispam-mysql.server.lock
-checkInitLock() {
-  if [ -f "$initlockfile" ]; then
-    initpid=$(cat "$initlockfile")
-    if [ "$initpid" != "" ]; then
-      kill -0 "$initpid" 2>/dev/null
-      rc=$?
-      if [ $rc -eq 0 ]; then
-        echo "$0 already running with pid $initpid"
-        exit 1
-      fi
-    fi
+getpid() {
+  pid=$(pgrep -f '/opt/zextras/.*/mysqld.*conf/antispam-my.cnf')
+}
+
+checkrunning() {
+  getpid
+  if [ "$pid" = "" ]; then
+    running=0
+  else
+    running=1
   fi
-  echo $$ >"$initlockfile"
 }
-
-trap "quit 1" SIGINT SIGQUIT
-trap "quit 1" SIGTERM
-quit() {
-  RC=$1
-  rc=${RC:=0}
-  cleanup
-  exit "$rc"
-}
-
-cleanup() {
-  [ -f "$initlockfile" ] && rm -f "$initlockfile"
-}
-
-#
-# If PID file for mysqld for antispam exists, grab the recorded PID
-#
-if [ -f "${antispam_mysql_pidfile}" ]; then
-  pid=$(cat "${antispam_mysql_pidfile}")
-fi
 
 case "$1" in
   'start')
-    checkInitLock
+    checkrunning
     if [ ! -d "${antispam_mysql_data_directory}" ]; then
       # The antispam mysql data directory does not appear to exist, assuming that db has not been initialized
       /opt/zextras/libexec/zmantispamdbinit
     fi
-    zmassert -r "${antispam_mysql_mycnf}"
-    zmassert -d "$(dirname "${antispam_mysql_pidfile}")"
-    if [ "$pid" != "" ]; then
-      kill -0 "$pid" 2>/dev/null
-      rc=$?
-      if [ $rc -eq 0 ]; then
-        echo "mysqld_safe for anti-spam already running with pid $pid"
-        quit 0
-      fi
+
+    assert -r "${antispam_mysql_mycnf}"
+    if [ $running = 1 ]; then
+      echo "mysqld_safe for anti-spam already running"
+      exit 0
     fi
+
     # --defaults-file must be first argument
     echo -n "Starting mysqld for anti-spam..."
     /opt/zextras/common/bin/mysqld_safe \
@@ -100,17 +71,17 @@ case "$1" in
       --external-locking \
       --malloc-lib=/opt/zextras/common/lib/libjemalloc.so \
       --ledir=/opt/zextras/common/sbin </dev/null >/dev/null 2>&1 &
-    SQLSTARTED=0
-    for ((i = 0; i < 60; i++)); do
-      /opt/zextras/bin/antispam-mysqladmin -s ping >/dev/null 2>&1
+    running=0
+    for ((i = 0; i < 10; i++)); do
+      /opt/zextras/bin/antispam-mysqladmin -s ping >/dev/null
       rc=$?
       if [ $rc -eq 0 ]; then
-        SQLSTARTED=1
+        running=1
         break
       fi
-      sleep 2
+      sleep 3
     done
-    if [ ${SQLSTARTED} -ne 1 ]; then
+    if [ ${running} -ne 1 ]; then
       echo "failed."
     else
       echo "done."
@@ -118,36 +89,36 @@ case "$1" in
     ;;
 
   'stop')
-    checkInitLock
-    if [ "${pid}" = "" ]; then
+    checkrunning
+    if [ $running = 0 ]; then
       # If mysql for antispam is enabled, then print the warning message.  Otherwise, we
       # shouldn't care that there is no PID file.
       if [ "${antispam_mysql_enabled}" == "TRUE" ]; then
-        echo "mysqld for anti-spam not running: no pid in '${antispam_mysql_pidfile}'"
+        echo "mysqld for anti-spam not running: no pid"
       fi
-      quit 0
+      exit 0
     else
       echo -n "Stopping mysqld for anti-spam..."
-      kill "$pid" >>"${antispam_mysql_errlogfile}" 2>&1
+      echo "$pid" | xargs kill >>"${antispam_mysql_errlogfile}" 2>&1
       # wait for mysqld pid file to be removed
       for ((i = 0; i < 30; i++)); do
         sleep 2
-        kill -0 "$pid" 2>/dev/null
+        echo "$pid" | xargs kill -0 2>/dev/null
         rc=$?
         if [ $rc -ne 0 ]; then
-          rm -f "${antispam_mysql_pidfile}"
           break
         fi
-        kill "$pid" >>"${antispam_mysql_errlogfile}" 2>&1
+        echo "$pid" | xargs kill >>"${antispam_mysql_errlogfile}" 2>&1
       done
-      if [ -s "${antispam_mysql_pidfile}" ]; then
+      rc=$?
+      if [ $rc -ne 0 ]; then
         echo "failed."
-        quit 1
+        exit 1
       else
         echo " done."
       fi
     fi
-    quit 0
+    exit 0
     ;;
 
   'restart' | 'reload')
@@ -156,18 +127,19 @@ case "$1" in
     ;;
 
   'status')
-    kill -0 "$pid" 2>/dev/null
-    mysqlstatus=$?
-    if [ $mysqlstatus -eq 0 ]; then
-      echo "mysql is running with pid $pid"
+    echo -n "mysql is "
+    checkrunning
+    if [ $running = 0 ]; then
+      echo "not running."
+      exit 1
     else
-      echo "mysql is not running"
+      echo "running."
+      exit 0
     fi
-    quit $mysqlstatus
     ;;
 
   *)
     echo "Usage: $0 start|stop|restart|reload|status"
-    quit 1
+    exit 0
     ;;
 esac

--- a/src/bin/antispam-mysqladmin
+++ b/src/bin/antispam-mysqladmin
@@ -16,6 +16,6 @@ if [ "127.0.0.1" != "${antispam_mysql_host}" ] &&
 fi
 
 exec /opt/zextras/common/bin/mysqladmin \
-  --socket="${antispam_mysql_socket}" \
+  --socket=/run/carbonio/antispam-mysql.sock \
   --user=root \
   --password="${antispam_mysql_root_password}" "$@"

--- a/src/bin/ldap.production
+++ b/src/bin/ldap.production
@@ -5,11 +5,6 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
-PID=""
-PIDFILE="/opt/zextras/data/ldap/state/run/slapd.pid"
-
-mkdir -p "/opt/zextras/data/ldap/state/run/"
-
 source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
@@ -21,44 +16,37 @@ if [ "$ldap_is_master" = "false" ]; then
 fi
 
 getpid() {
-  if [ -f $PIDFILE ]; then
-    PID=$(cat $PIDFILE)
-  fi
+  pid=$(pidof /opt/zextras/common/libexec/slapd)
 }
 
 checkrunning() {
   getpid
-  if [ "$PID" = "" ]; then
-    RUNNING=0
+  if [ "$pid" = "" ]; then
+    running=0
   else
-    if ps --no-headers -p "$PID" -o cmd 2>/dev/null | grep slapd >/dev/null 2>&1; then
-      RUNNING=1
-    else
-      PID=""
-      RUNNING=0
-    fi
+    running=1
   fi
 }
 
 checkListening() {
-  SEARCHTIMEOUT=30 #timelimit for ldapsearch
+  searchtimeout=30 #timelimit for ldapsearch
   if [ "$ldap_common_require_tls" = "0" ]; then
-    /opt/zextras/common/bin/ldapsearch -x -l $SEARCHTIMEOUT -b "" -s base -H ldapi:/// >/dev/null 2>&1
+    /opt/zextras/common/bin/ldapsearch -x -l $searchtimeout -b "" -s base -H ldapi:/// >/dev/null 2>&1
   else
-    /opt/zextras/common/bin/ldapsearch -ZZ -x -l $SEARCHTIMEOUT -b "" -s base -H ldapi:/// >/dev/null 2>&1
+    /opt/zextras/common/bin/ldapsearch -ZZ -x -l $searchtimeout -b "" -s base -H ldapi:/// >/dev/null 2>&1
   fi
   rc=$?
   if [ $rc -ne 0 ]; then
-    LISTENING=0
+    listening=0
   else
-    LISTENING=1
+    listening=1
   fi
 }
 
 start() {
   checkrunning
-  if [ $RUNNING != 0 ]; then
-    echo "slapd already running: pid $PID"
+  if [ $running != 0 ]; then
+    echo "slapd already running: pid $pid"
     exit 1
   fi
   # Our ldap url should be the first in the list in localconfig
@@ -68,7 +56,7 @@ start() {
   fi
   for ((i = 0; i <= 30; i++)); do
     checkrunning
-    if [ $RUNNING = 0 ]; then
+    if [ $running = 0 ]; then
       if ((i % 5 == 0)); then
         /opt/zextras/libexec/zmslapd -l LOCAL0 \
           -h "${bind_url} ldapi:///" -F /opt/zextras/data/ldap/config
@@ -78,19 +66,19 @@ start() {
     fi
     sleep 1
   done
-  if [ "$PID" = "" ]; then
+  if [ "$pid" = "" ]; then
     echo "Failed to start slapd."
   else
-    echo "Started slapd: pid $PID"
+    echo "Started slapd: pid $pid"
   fi
   for ((i = 0; i < 30; i++)); do
     checkListening
-    if [ $LISTENING = 1 ]; then
+    if [ $listening = 1 ]; then
       break
     fi
     sleep 1
   done
-  if [ "$LISTENING" = 0 ]; then
+  if [ "$listening" = 0 ]; then
     echo "Error: Unable to check that slapd is listening to connections"
     exit 1
   fi
@@ -99,14 +87,14 @@ start() {
 stop() {
   checkrunning
 
-  if [ $RUNNING = 0 ]; then
+  if [ $running = 0 ]; then
     echo "slapd not running"
     exit 0
   fi
-  echo -n "Killing slapd with pid $PID"
-  kill "$PID"
+  echo -n "Killing slapd with pid $pid"
+  kill "$pid" 2>/dev/null
   for ((i = 0; i < 1500; i++)); do
-    if ! kill -0 "$PID" 2>/dev/null; then
+    if ! kill -0 "$pid" 2>/dev/null; then
       echo " done."
       exit 0
     fi
@@ -115,7 +103,7 @@ stop() {
     fi
     sleep 1
   done
-  if kill "$PID"; then
+  if kill "$pid" 2>/dev/null; then
     echo " gave up waiting!"
     exit 1
   fi
@@ -125,10 +113,10 @@ stop() {
 
 status() {
   checkrunning
-  if [ $RUNNING = 0 ]; then
+  if [ $running = 0 ]; then
     exit 1
   else
-    echo "slapd running pid: $PID"
+    echo "slapd running pid: $pid"
     exit 0
   fi
 }

--- a/src/bin/mysql
+++ b/src/bin/mysql
@@ -8,5 +8,5 @@
 source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
-exec /opt/zextras/common/bin/mysql -S "${mysql_socket}" \
+exec /opt/zextras/common/bin/mysql -S /run/carbonio/mysql.sock \
   -u "${zimbra_mysql_user}" --password="${zimbra_mysql_password}" "$@"

--- a/src/bin/mysql.server
+++ b/src/bin/mysql.server
@@ -25,58 +25,30 @@ if [ ! -d "${zimbra_tmp_directory}/mysql" ]; then
   mkdir -p "${zimbra_tmp_directory}/mysql" >/dev/null 2>&1
 fi
 
-zmassert -d "${zimbra_tmp_directory}"
-zmassert -r "${mysql_mycnf}"
-zmassert -d "$(dirname "${mysql_pidfile}")"
+assert -d "${zimbra_tmp_directory}"
+assert -r "${mysql_mycnf}"
 
-# innodb will open the database before binding and writing out the pid
-# potentially corrupting the files
-# prevent multiple init scripts from running at the same time.
-initlockfile=${zimbra_tmp_directory}/mysql/mysql.server.lock
-checkInitLock() {
-  if [ -f "$initlockfile" ]; then
-    initpid=$(cat "$initlockfile")
-    if [ "$initpid" != "" ]; then
-      kill -0 "$initpid" 2>/dev/null
-      rc=$?
-      if [ $rc -eq 0 ]; then
-        echo "$0 already running with pid $initpid"
-        exit 1
-      fi
-    fi
+getpid() {
+  pid=$(pgrep -f '/opt/zextras/.*/mysqld.*conf/my.cnf')
+}
+
+checkrunning() {
+  getpid
+  if [ "$pid" = "" ]; then
+    running=0
+  else
+    running=1
   fi
-  echo $$ >"$initlockfile"
 }
-trap "quit 1" SIGINT SIGQUIT
-trap "quit 1" SIGTERM
-quit() {
-  RC=$1
-  rc=${RC:=0}
-  cleanup
-  exit "$rc"
-}
-cleanup() {
-  [ -f "$initlockfile" ] && rm -f "$initlockfile"
-}
-
-#
-# Path to my.cnf
-#
-if [ -f "${mysql_pidfile}" ]; then
-  pid=$(cat "${mysql_pidfile}")
-fi
 
 case "$1" in
   'start')
-    checkInitLock
-    if [ "$pid" != "" ]; then
-      kill -0 "$pid" 2>/dev/null
-      rc=$?
-      if [ $rc -eq 0 ]; then
-        echo "mysqld_safe already running with pid $pid"
-        quit 0
-      fi
+    checkrunning
+    if [ $running = 1 ]; then
+      echo "mysqld_safe already running"
+      exit 0
     fi
+
     # --defaults-file must be first argument
     echo -n "Starting mysqld..."
     /opt/zextras/common/bin/mysqld_safe \
@@ -85,17 +57,17 @@ case "$1" in
       --log-error="${mysql_errlogfile}" \
       --malloc-lib=/opt/zextras/common/lib/libjemalloc.so \
       --ledir=/opt/zextras/common/sbin </dev/null >/dev/null 2>&1 &
-    SQLSTARTED=0
-    for ((i = 0; i < 60; i++)); do
+    running=0
+    for ((i = 0; i < 10; i++)); do
       /opt/zextras/bin/mysqladmin -s ping >/dev/null
       rc=$?
       if [ $rc -eq 0 ]; then
-        SQLSTARTED=1
+        running=1
         break
       fi
-      sleep 2
+      sleep 3
     done
-    if [ ${SQLSTARTED} -ne 1 ]; then
+    if [ ${running} -ne 1 ]; then
       echo "failed."
     else
       echo "done."
@@ -103,32 +75,32 @@ case "$1" in
     ;;
 
   'stop')
-    checkInitLock
-    if [ "${pid}" = "" ]; then
-      echo "mysqld not running: no pid in '${mysql_pidfile}'"
-      quit 0
+    checkrunning
+    if [ $running = 0 ]; then
+      echo "mysqld not running: no pid"
+      exit 0
     else
       echo -n "Stopping mysqld..."
-      kill "$pid" >>"${mysql_errlogfile}" 2>&1
+      echo "$pid" | xargs kill >>"${mysql_errlogfile}" 2>&1
       # wait for mysqld pid file to be removed
       for ((i = 0; i < zimbra_mysql_shutdown_timeout; i++)); do
         sleep 2
-        kill -0 "$pid" 2>/dev/null
+        echo "$pid" | xargs kill -0 2>/dev/null
         rc=$?
         if [ $rc -ne 0 ]; then
-          rm -f "${mysql_pidfile}"
           break
         fi
-        kill "$pid" >>"${mysql_errlogfile}" 2>&1
+        echo "$pid" | xargs kill >>"${mysql_errlogfile}" 2>&1
       done
-      if [ -s "${mysql_pidfile}" ]; then
+      rc=$?
+      if [ $rc -ne 0 ]; then
         echo "failed."
-        quit 1
+        exit 1
       else
         echo " done."
       fi
     fi
-    quit 0
+    exit 0
     ;;
 
   'restart' | 'reload')
@@ -137,18 +109,19 @@ case "$1" in
     ;;
 
   'status')
-    kill -0 "$pid" 2>/dev/null
-    mysqlstatus=$?
-    if [ $mysqlstatus -eq 0 ]; then
-      echo "mysql is running with pid $pid"
+    echo -n "mysql is "
+    checkrunning
+    if [ $running = 0 ]; then
+      echo "not running."
+      exit 1
     else
-      echo "mysql is not running"
+      echo "running."
+      exit 0
     fi
-    quit $mysqlstatus
     ;;
 
   *)
     echo "Usage: $0 start|stop|restart|reload|status"
-    quit 1
+    exit 0
     ;;
 esac

--- a/src/bin/mysqladmin
+++ b/src/bin/mysqladmin
@@ -8,4 +8,7 @@
 source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
-exec /opt/zextras/common/bin/mysqladmin -S "${mysql_socket}" -u root --password="${mysql_root_password}" "$@"
+exec /opt/zextras/common/bin/mysqladmin \
+  -S /run/carbonio/mysql.sock \
+  -u root \
+  --password="${mysql_root_password}" "$@"

--- a/src/bin/zmamavisdctl
+++ b/src/bin/zmamavisdctl
@@ -27,48 +27,48 @@ rewriteconfig() {
 }
 
 checkrunning() {
-  # Get PID from scanning the proc table.
-  if [ "$PID" = "" ]; then
-    # PID file is NULL.  Get info from proc table.
-    PID=$(ps axo user,pid,ppid,command | awk '{ if ((($4 ~ /^amavisd$/) || ($4 ~ /^\/opt\/zextras\/common\/sbin\/amavisd$/)) && ($5 ~ /^\(master\)$/)) { print $2 } }')
+  # Get pid from scanning the proc table.
+  if [ "$pid" = "" ]; then
+    # pid file is NULL.  Get info from proc table.
+    pid=$(ps axo user,pid,ppid,command | awk '{ if ((($4 ~ /^amavisd$/) || ($4 ~ /^\/opt\/zextras\/common\/sbin\/amavisd$/)) && ($5 ~ /^\(master\)$/)) { print $2 } }')
   fi
-  # If PID is still not set, then we cannot find any amavisd (master) process.  Assume amavisd is not running.
-  if [ "$PID" = "" ]; then
-    RUNNING=0
+  # If pid is still not set, then we cannot find any amavisd (master) process.  Assume amavisd is not running.
+  if [ "$pid" = "" ]; then
+    running=0
     return
   fi
 
-  # If we get to this point the PID was defined in the PID file.  But we're not sure we trust it's validity
+  # If we get to this point the pid was defined in the pid file.  But we're not sure we trust it's validity
   # so we're going the verify it from ps output!
-  PID=$(ps axo user,pid,ppid,command | awk '{ if (($2 == "$PID") && (($4 ~ /^amavisd$/) || ($4 ~ /^\/opt\/zextras\/common\/sbin\/amavisd$/)) && ($5 ~ /^\(master\)$/)) { print $2 } }')
-  # If PID is NULL now, then the PID stored in the PID file was bogus!
+  pid=$(ps axo user,pid,ppid,command | awk '{ if (($2 == "$pid") && (($4 ~ /^amavisd$/) || ($4 ~ /^\/opt\/zextras\/common\/sbin\/amavisd$/)) && ($5 ~ /^\(master\)$/)) { print $2 } }')
+  # If pid is NULL now, then the pid stored in the pid file was bogus!
   # Let's try to find the true amavisd (master) process ID
-  if [ "$PID" = "" ]; then
-    PID=$(ps axo user,pid,ppid,command | awk '{ if ((($4 ~ /^amavisd$/) || ($4 ~ /^\/opt\/zextras\/common\/sbin\/amavisd$/)) && ($5 ~ /^\(master\)$/)) { print $2 } }')
+  if [ "$pid" = "" ]; then
+    pid=$(ps axo user,pid,ppid,command | awk '{ if ((($4 ~ /^amavisd$/) || ($4 ~ /^\/opt\/zextras\/common\/sbin\/amavisd$/)) && ($5 ~ /^\(master\)$/)) { print $2 } }')
   fi
-  # If the PID is still NULL now, it really must not be running.
-  if [ "$PID" = "" ]; then
-    RUNNING=0
+  # If the pid is still NULL now, it really must not be running.
+  if [ "$pid" = "" ]; then
+    running=0
     return
   else
-    RUNNING=1
+    running=1
     return
   fi
 }
 
 checkrunning-mc() {
-  #  Get PID from scanning the proc table.
-  if [ "$MCPID" = "" ]; then
-    # PID file is NULL.  Get info from proc table.
-    MCPID=$(ps axo user,pid,ppid,command | awk '{ if ((($6 ~ /amavis-mc$/) || ($6 ~ /\/opt\/zextras\/common\/sbin\/amavis-mc$/))) { print $2 } }')
+  #  Get pid from scanning the proc table.
+  if [ "$mcpid" = "" ]; then
+    # pid file is NULL.  Get info from proc table.
+    mcpid=$(ps axo user,pid,ppid,command | awk '{ if ((($6 ~ /amavis-mc$/) || ($6 ~ /\/opt\/zextras\/common\/sbin\/amavis-mc$/))) { print $2 } }')
   fi
-  # If PID is still not set, then we cannot find any amavisd (master) process.  Assume amavisd is not running.
-  if [ "$MCPID" = "" ]; then
-    MCRUNNING=0
+  # If pid is still not set, then we cannot find any amavisd (master) process.  Assume amavisd is not running.
+  if [ "$mcpid" = "" ]; then
+    mcrunning=0
     return
   fi
 
-  MCRUNNING=1
+  mcrunning=1
   return
 }
 
@@ -79,20 +79,20 @@ case "$1" in
   'start')
     checkrunning-mc
     echo -n "Starting amavisd-mc..."
-    if [ $MCRUNNING = 1 ]; then
+    if [ $mcrunning = 1 ]; then
       echo "amavisd-mc is already running."
     else
-      if [ $MCRUNNING = 0 ]; then
+      if [ $mcrunning = 0 ]; then
         sudo /opt/zextras/common/sbin/amavis-mc
         for ((i = 0; i < 30; i++)); do
           checkrunning-mc
-          if [ $MCRUNNING = 1 ]; then
+          if [ $mcrunning = 1 ]; then
             break
           fi
           sleep 1
         done
       fi
-      if [ "$MCPID" = "" ]; then
+      if [ "$mcpid" = "" ]; then
         echo "failed."
         exit
       else
@@ -101,7 +101,7 @@ case "$1" in
     fi
     checkrunning
     echo -n "Starting amavisd..."
-    if [ $RUNNING = 1 ]; then
+    if [ $running = 1 ]; then
       echo "amavisd is already running."
       exit 0
     else
@@ -123,12 +123,12 @@ case "$1" in
         /opt/zextras/conf/amavisd.conf &
       for ((i = 0; i < 30; i++)); do
         checkrunning
-        if [ $RUNNING = 1 ]; then
+        if [ $running = 1 ]; then
           break
         fi
         sleep 1
       done
-      if [ "$PID" = "" ]; then
+      if [ "$pid" = "" ]; then
         echo "failed."
       else
         echo "done."
@@ -143,47 +143,47 @@ case "$1" in
   'stop')
     checkrunning
     echo -n "Stopping amavisd..."
-    if [ $RUNNING = 0 ]; then
+    if [ $running = 0 ]; then
       echo "amavisd is not running."
     else
-      kill "$PID" 2>/dev/null
+      kill "$pid" 2>/dev/null
       for ((i = 0; i < 300; i++)); do
         sleep 5
-        kill -0 "$PID" 2>/dev/null
+        kill -0 "$pid" 2>/dev/null
         rc=$?
         if [ $rc -ne 0 ]; then
           break
         fi
       done
-      kill "$PID" 2>/dev/null
+      kill "$pid" 2>/dev/null
       rc=$?
       if [ $rc -ne 0 ]; then
         echo " done."
       else
-        echo " failed to stop $PID"
+        echo " failed to stop $pid"
         exit 1
       fi
     fi
     checkrunning-mc
     echo -n "Stopping amavisd-mc..."
-    if [ $MCRUNNING = 0 ]; then
+    if [ $mcrunning = 0 ]; then
       echo "amavisd-mc is not running."
     else
-      kill "$MCPID" 2>/dev/null
+      kill "$mcpid" 2>/dev/null
       for ((i = 0; i < 300; i++)); do
         sleep 5
-        kill -0 "$MCPID" 2>/dev/null
+        kill -0 "$mcpid" 2>/dev/null
         rc=$?
         if [ $rc -ne 0 ]; then
           break
         fi
       done
-      kill "$MCPID" 2>/dev/null
+      kill "$mcpid" 2>/dev/null
       rc=$?
       if [ $rc -ne 0 ]; then
         echo " done."
       else
-        echo " failed to stop $PID"
+        echo " failed to stop $pid"
         exit 1
       fi
     fi
@@ -198,7 +198,7 @@ case "$1" in
   'status')
     checkrunning
     echo -n "amavisd is "
-    if [ $RUNNING = 0 ]; then
+    if [ $running = 0 ]; then
       echo "not running."
       exit 1
     else
@@ -206,7 +206,7 @@ case "$1" in
     fi
     checkrunning-mc
     echo -n "amavisd-mc is "
-    if [ $MCRUNNING = 0 ]; then
+    if [ $mcrunning = 0 ]; then
       echo "not running."
       exit 1
     else

--- a/src/bin/zmcbpolicydctl
+++ b/src/bin/zmcbpolicydctl
@@ -13,7 +13,6 @@ fi
 source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
-pidfile=${cbpolicyd_pid_file:=${zimbra_log_directory}/cbpolicyd.pid}
 dbfile=${cbpolicyd_db_file:=/opt/zextras/data/cbpolicyd/db/cbpolicyd.sqlitedb}
 
 rewriteconfig() {
@@ -21,27 +20,15 @@ rewriteconfig() {
 }
 
 getpid() {
-  if [ -f "$pidfile" ]; then
-    PID=$(cat "$pidfile")
-  fi
+  pid=$(pidof /opt/zextras/common/bin/cbpolicyd)
 }
 
 checkrunning() {
   getpid
-  if [ "$PID" = "" ]; then
-    RUNNING=0
-    if [ -f "$pidfile" ]; then
-      rm -f "$pidfile"
-    fi
+  if [ "$pid" = "" ]; then
+    running=0
   else
-    kill -0 "$PID" 2>/dev/null
-    rc=$?
-    if [ $rc -ne 0 ]; then
-      PID=""
-      RUNNING=0
-    else
-      RUNNING=1
-    fi
+    running=1
   fi
 }
 
@@ -57,7 +44,7 @@ case "$1" in
     checkrunning
 
     echo -n "Starting policyd..."
-    if [ $RUNNING = 1 ]; then
+    if [ $running = 1 ]; then
       echo "policyd is already running."
       exit 0
     else
@@ -79,11 +66,11 @@ case "$1" in
       for ((i = 0; i < 30; i++)); do
         sleep 1
         checkrunning
-        if [ $RUNNING = 1 ]; then
+        if [ $running = 1 ]; then
           break
         fi
       done
-      if [ "$PID" = "" ]; then
+      if [ "$pid" = "" ]; then
         echo "failed."
         exit 1
       else
@@ -99,24 +86,24 @@ case "$1" in
   'stop')
     checkrunning
     echo -n "Stopping policyd..."
-    if [ $RUNNING = 0 ]; then
+    if [ $running = 0 ]; then
       echo "policyd is not running."
       exit 0
     else
-      kill "$PID" 2>/dev/null
+      kill "$pid" 2>/dev/null
       for ((i = 0; i < 300; i++)); do
         sleep 5
-        kill -0 "$PID" 2>/dev/null
+        kill -0 "$pid" 2>/dev/null
         rc=$?
         if [ $rc -ne 0 ]; then
           echo " done."
           exit 0
         fi
       done
-      kill "$PID" 2>/dev/null
+      kill "$pid" 2>/dev/null
       rc=$?
       if [ $rc -eq 0 ]; then
-        echo " failed to stop $PID"
+        echo " failed to stop $pid"
         exit 1
       else
         echo " done."
@@ -133,7 +120,7 @@ case "$1" in
   'status')
     checkrunning
     echo -n "policyd is "
-    if [ $RUNNING = 0 ]; then
+    if [ $running = 0 ]; then
       echo "not running."
       exit 1
     else

--- a/src/bin/zmclamdctl
+++ b/src/bin/zmclamdctl
@@ -17,8 +17,6 @@ fi
 source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
-pidfile=${zimbra_log_directory}/clamd.pid
-
 if [ ! -d "/opt/zextras/data/clamav/db" ]; then
   mkdir -p /opt/zextras/data/clamav/db
 fi
@@ -28,24 +26,16 @@ rewriteconfig() {
 }
 
 getpid() {
-  if [ -f "$pidfile" ]; then
-    cpid=$(cat "$pidfile")
-  fi
+  pid=$(pidof /opt/zextras/common/sbin/clamd)
 }
 
 checkrunning() {
   getpid
   # clamd
-  if [ "$cpid" = "" ]; then
+  if [ "$pid" = "" ]; then
     running=0
   else
-    if ps --no-headers -p "$cpid" -o cmd 2>/dev/null | grep clamd >/dev/null 2>&1; then
-      running=1
-    else
-      rm "$pidfile"
-      cpid=""
-      running=0
-    fi
+    running=1
   fi
 }
 
@@ -88,10 +78,8 @@ case "$1" in
     ;;
 
   'kill')
-    if [ -f /opt/zextras/log/clamd.pid ]; then
-      cpid=$(cat /opt/zextras/log/clamd.pid)
-      kill "$cpid" 2>/dev/null
-    fi
+    pid=$(pidof /opt/zextras/common/sbin/clamd)
+    kill "$pid" 2>/dev/null
     pskillall /opt/zextras/common/sbin/clamd
     exit 0
     ;;
@@ -102,24 +90,22 @@ case "$1" in
     if [ $running = 0 ]; then
       echo "clamd is not running."
     else
-      if [ "$cpid" != "" ]; then
-        kill "$cpid" 2>/dev/null
-      fi
+      kill "$pid" 2>/dev/null
       for ((i = 0; i < 30; i++)); do
         sleep 2
-        kill -0 "$cpid" 2>/dev/null
+        kill -0 "$pid" 2>/dev/null
         rc=$?
         if [ $rc -ne 0 ]; then
-          rm -f "${pidfile}"
           break
         fi
-        kill "$cpid"
+        kill "$pid"
       done
-      if [ -s "${pidfile}" ]; then
+      rc=$?
+      if [ $rc -ne 0 ]; then
         echo "failed."
-        exit 1
+        quit 1
       else
-        echo "done."
+        echo " done."
       fi
     fi
     exit 0

--- a/src/bin/zmconfigdctl
+++ b/src/bin/zmconfigdctl
@@ -24,22 +24,17 @@ if [ "$JYTHONPATH" = "" ]; then
 fi
 
 pid=""
-pidfile="${zimbra_log_directory}/zmconfigd.pid"
 
 NC=$(command -v nc 2>/dev/null)
 NC=${NC:-$(command -v netcat 2>/dev/null)}
 
 getpid() {
-  if [[ -f ${pidfile} ]]; then
-    pid=$(cat "${pidfile}")
-  fi
+  pid=$(pgrep -f '/opt/zextras/.*/java.*configd')
 }
 
 checkrunning() {
   getpid
-  if [[ "${pid}" = "0" ]]; then
-    pid=$(pgrep -f zmconfigd)
-  fi
+
   if [[ "${pid}" = "" ]]; then
     running=0
   else
@@ -55,44 +50,48 @@ checkrunning() {
 
 startzmconfigd() {
   err=0
-  checkrunning
+
   echo -n "Starting zmconfigd..."
-  if [[ ${running} = 1 ]]; then
+  checkrunning
+
+  if [[ ${running} -eq 1 ]]; then
     echo "zmconfigd is already running."
     return
   fi
-  if [[ ${JYTHONPATH} = "" ]]; then
-    echo "JYTHONPATH is unset!"
+
+  if [[ -z "${JYTHONPATH}" ]]; then
+    echo "Error: JYTHONPATH is unset!"
     err=1
     return
   fi
-  if [[ "${pid}" != "" ]]; then
-    kill "${pid}"
+
+  executable="/opt/zextras/libexec/zmconfigd"
+  if [[ ! -x "${executable}" ]]; then
+    echo "Error: zmconfigd executable does not exist or is not executable."
+    err=1
+    return
   fi
-  rm -rf "${pidfile}"
-  /opt/zextras/libexec/zmconfigd >/dev/null 2>&1 &
-  for ((i = 0; i < 30; i++)); do
-    if [[ -f ${pidfile} ]]; then
-      break
-    fi
-    sleep 1
-  done
-  for ((i = 0; i < zmconfigd_startup_pause; i++)); do
+
+  # Kill existing process if PID is found
+  if [[ -n "${pid}" ]]; then
+    kill "${pid}" || { echo "Warning: Failed to kill existing zmconfigd process."; }
+  fi
+
+  # Start new process
+  "${executable}" >/dev/null 2>&1 &
+
+  # Wait for the process to start
+  for ((i = 0; i < 10; i++)); do
     checkrunning
-    if [[ ${running} = 1 ]]; then
+    if [[ ${running} -eq 1 ]]; then
       echo "done."
       return
     fi
-    if [[ ${running} = -1 ]]; then
-      echo "Failed to start"
-      err=1
-      return
-    fi
-    sleep 1
+    sleep 3
   done
-  echo "failed."
+
+  echo "Failed to start zmconfigd."
   err=1
-  return
 }
 
 case "$1" in
@@ -108,22 +107,18 @@ case "$1" in
       echo "zmconfigd is not running."
       exit 0
     else
-      for ((i = 0; i < 30; i++)); do
+      kill "${pid}" 2>/dev/null
+      for ((i = 0; i < 10; i++)); do
         if ! kill -0 "${pid}" 2>/dev/null; then
-          rm -rf "${pidfile}"
-          break
+          echo "done."
+          exit 0
         fi
-        kill "${pid}"
-        sleep 1
+        sleep 3
       done
-    fi
-    if [[ -s ${pidfile} ]]; then
-      echo "failed."
+      kill -9 "${pid}" 2>/dev/null
+      echo "failed to stop gracefully, process killed."
       exit 1
-    else
-      echo "done."
     fi
-    exit 0
     ;;
 
   'restart' | 'reload')

--- a/src/bin/zmfreshclamctl
+++ b/src/bin/zmfreshclamctl
@@ -17,31 +17,21 @@ fi
 source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
-fpidfile=${zimbra_log_directory}/freshclam.pid
-
 rewriteconfig() {
   /opt/zextras/libexec/configrewrite antivirus >/dev/null 2>&1
 }
 
 getpid() {
-  if [ -f "$fpidfile" ]; then
-    fpid=$(cat "$fpidfile")
-  fi
+  pid=$(pidof /opt/zextras/common/bin/freshclam)
 }
 
 checkrunning() {
   getpid
   # freshclam
-  if [ "$fpid" = "" ]; then
-    frunning=0
+  if [ "$pid" = "" ]; then
+    running=0
   else
-    if ps --no-headers -p "$fpid" -o cmd 2>/dev/null | grep freshclam >/dev/null 2>&1; then
-      frunning=1
-    else
-      rm "$fpidfile"
-      fpid=""
-      frunning=0
-    fi
+    running=1
   fi
 }
 
@@ -63,7 +53,7 @@ case "$1" in
 
     checkrunning
     echo -n "Starting freshclam..."
-    if [ $frunning = 1 ]; then
+    if [ $running = 1 ]; then
       echo "freshclam is already running."
     else
       /opt/zextras/common/bin/freshclam \
@@ -75,8 +65,8 @@ case "$1" in
     ;;
 
   'kill')
-    if [ -f /opt/zextras/log/freshclam.pid ]; then
-      cpid=$(cat /opt/zextras/log/freshclam.pid)
+    if [[ "${pid}" != "" ]]; then
+      pid=$(pidof /opt/zextras/common/bin/freshclam)
       kill "$cpid" 2>/dev/null
     fi
     pskillall /opt/zextras/common/bin/freshclam
@@ -86,17 +76,15 @@ case "$1" in
   'stop')
     checkrunning
     echo -n "Stopping freshclam..."
-    if [ $frunning = 0 ]; then
+    if [ $running = 0 ]; then
       echo "freshclam is not running."
     else
-      if [ "$fpid" != "" ]; then
-        kill "$fpid" 2>/dev/null
-        rc=$?
-        if [ $rc -eq 0 ]; then
-          echo "done."
-        else
-          echo "failed."
-        fi
+      kill "$pid" 2>/dev/null
+      rc=$?
+      if [ $rc -eq 0 ]; then
+        echo "done."
+      else
+        echo "failed."
       fi
     fi
 
@@ -111,7 +99,7 @@ case "$1" in
   'status')
     checkrunning
     echo -n "freshclam is "
-    if [ $frunning = 1 ]; then
+    if [ $running = 1 ]; then
       echo "running."
       exit 0
     else

--- a/src/bin/zmhostname
+++ b/src/bin/zmhostname
@@ -6,5 +6,5 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
 source /opt/zextras/bin/zmshutil || exit 1
-zmassert -r /opt/zextras/conf/localconfig.xml
+assert -r /opt/zextras/conf/localconfig.xml
 /opt/zextras/bin/zmlocalconfig -m nokey zimbra_server_hostname

--- a/src/bin/zminnotop
+++ b/src/bin/zminnotop
@@ -38,8 +38,13 @@ zmsetvars
 if [ -x "/opt/zextras/common/bin/innotop" ]; then
   if [ "$1" = "-r" ]; then
     shift
-    /opt/zextras/common/bin/innotop --socket "$mysql_socket" --user root --password "$mysql_root_password" "$@"
+    /opt/zextras/common/bin/innotop \
+      --socket /run/carbonio/mysql.sock \
+      --user root --password "$mysql_root_password" "$@"
   else
-    /opt/zextras/common/bin/innotop --socket "$mysql_socket" --user "$zimbra_mysql_user" --password "$zimbra_mysql_password" "$@"
+    /opt/zextras/common/bin/innotop \
+      --socket /run/carbonio/mysql.sock \
+      --user "$zimbra_mysql_user" \
+      --password "$zimbra_mysql_password" "$@"
   fi
 fi

--- a/src/bin/zmmailboxdctl
+++ b/src/bin/zmmailboxdctl
@@ -38,18 +38,28 @@ if [ -e ${spnego_options_file} ]; then
   spnegoJavaOptions=$(cat $spnego_options_file)
 fi
 
-#
-# Main
-#
+getpid() {
+  pid=$(pgrep -f '/opt/zextras/.*/java.*mailboxd')
+}
+
+checkrunning() {
+  getpid
+  if [ "$pid" = "" ]; then
+    running=0
+  else
+    running=1
+  fi
+}
+
 case "$1" in
   'start')
     if [ "$2" = "" ]; then
       /opt/zextras/bin/zmtlsctl >/dev/null 2>&1
     fi
-    /opt/zextras/libexec/zmmailboxdmgr status
-    rc=$?
-    if [ $rc -eq 0 ]; then
-      echo "mailboxd already running."
+
+    checkrunning
+    if [ $running = 1 ]; then
+      echo "mailboxd is already running."
       exit 0
     fi
 
@@ -71,9 +81,23 @@ case "$1" in
 
     echo -n "Starting mailboxd..."
     # shellcheck disable=SC2086
-    /opt/zextras/libexec/zmmailboxdmgr start \
-      -Dfile.encoding=UTF-8 ${mailboxd_java_options} ${spnegoJavaOptions} -Xms${javaXms}m \
-      "-Xmx${javaXmx}m" </dev/null >/dev/null 2>&1
+    /opt/zextras/common/bin/java \
+      -Dfile.encoding=UTF-8 \
+      $mailboxd_java_options \
+      -Xms${javaXms}m \
+      -Xmx${javaXmx}m \
+      -Djava.io.tmpdir=/opt/zextras/mailboxd/work \
+      -Djava.library.path=/opt/zextras/lib \
+      -Dzimbra.config=/opt/zextras/conf/localconfig.xml \
+      --module-path /opt/zextras/mailboxd/common/endorsed \
+      -Djetty.base=/opt/zextras/mailboxd \
+      -Djetty.home=/opt/zextras/common/jetty_home \
+      -DSTART=/opt/zextras/mailboxd/etc/start.config \
+      -jar /opt/zextras/common/jetty_home/start.jar \
+      --module=zimbra,server,mail,servlet,servlets,jsp,jstl,jmx,resources,websocket,ext,plus,rewrite,continuation,webapp,setuid \
+      jetty.home=/opt/zextras/common/jetty_home \
+      jetty.base=/opt/zextras/mailboxd \
+      /opt/zextras/mailboxd/etc/jetty.xml >/dev/null 2>&1 &
     rc=$?
     if [ $rc != 0 ]; then
       echo "failed."
@@ -100,16 +124,16 @@ case "$1" in
     ;;
 
   'kill' | 'stop')
+    checkrunning
     echo -n "Stopping mailboxd..."
-    /opt/zextras/libexec/zmmailboxdmgr status
-    rc=$?
-    if [ $rc -ne 0 ]; then
-      echo "mailboxd is not running."
+    if [ $running = 0 ]; then
+      echo "${servicename} is not running."
       exit 0
+    else
+      /opt/zextras/bin/zmthrdump -i -o /opt/zextras/log/stacktrace.$$."$(date +%Y%m%d%H%M%S)" 2>/dev/null
+      kill "$pid" 2>/dev/null
+      rc=$?
     fi
-    /opt/zextras/bin/zmthrdump -i -o /opt/zextras/log/stacktrace.$$."$(date +%Y%m%d%H%M%S)" 2>/dev/null
-    /opt/zextras/libexec/zmmailboxdmgr stop
-    rc=$?
     if [ $rc -eq 0 ]; then
       echo "done."
     else
@@ -125,14 +149,13 @@ case "$1" in
 
   'status')
     echo -n "mailboxd is "
-    /opt/zextras/libexec/zmmailboxdmgr status
-    rc=$?
-    if [ $rc -eq 0 ]; then
-      echo "running."
-      exit 0
-    else
+    checkrunning
+    if [ $running = 0 ]; then
       echo "not running."
       exit 1
+    else
+      echo "running."
+      exit 0
     fi
     ;;
 

--- a/src/bin/zmmemcachedctl
+++ b/src/bin/zmmemcachedctl
@@ -13,14 +13,10 @@ fi
 source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
-servicename=memcached
-pidfile=${zimbra_log_directory}/${servicename}.pid
 pid=""
 
 getpid() {
-  if [ -f "${pidfile}" ]; then
-    pid=$(cat "${pidfile}")
-  fi
+  pid=$(pidof /opt/zextras/common/bin/memcached)
 }
 
 checkrunning() {
@@ -28,12 +24,7 @@ checkrunning() {
   if [ "$pid" = "" ]; then
     running=0
   else
-    if ps --no-headers -p "$pid" -o cmd 2>/dev/null | grep memcached >/dev/null 2>&1; then
-      running=1
-    else
-      pid=""
-      running=0
-    fi
+    running=1
   fi
 }
 
@@ -46,9 +37,9 @@ case "$1" in
     fi
 
     checkrunning
-    echo -n "Starting ${servicename}..."
+    echo -n "Starting memcached..."
     if [ $running = 1 ]; then
-      echo "${servicename} is already running."
+      echo "memcached is already running."
       exit 0
     fi
 
@@ -56,9 +47,9 @@ case "$1" in
     addr="${addr//$'\n'/,}"
     port=$(/opt/zextras/bin/zmprov -l gs "${zimbra_server_hostname}" zimbraMemcachedBindPort | awk '/^zimbraMemcachedBindPort:/{ print $2 }')
     if [ "$addr" = "" ]; then
-      /opt/zextras/common/bin/${servicename} -d -P "${pidfile}" -U 0 -l 127.0.1.1,127.0.0.1 -p "${port:-11211}"
+      /opt/zextras/common/bin/memcached -d -U 0 -l 127.0.1.1,127.0.0.1 -p "${port:-11211}"
     else
-      /opt/zextras/common/bin/${servicename} -d -P "${pidfile}" -U 0 -l "${addr}" -p "${port:-11211}"
+      /opt/zextras/common/bin/memcached -d -U 0 -l "${addr}" -p "${port:-11211}"
     fi
     for ((i = 0; i < 30; i++)); do
       checkrunning
@@ -77,23 +68,22 @@ case "$1" in
     ;;
   stop)
     checkrunning
-    echo -n "Stopping ${servicename}..."
+    echo -n "Stopping memcached..."
     if [ $running = 0 ]; then
-      echo "${servicename} is not running."
+      echo "memcached is not running."
       exit 0
     else
       for ((i = 0; i < 30; i++)); do
         kill -0 "$pid" 2>/dev/null
         rc=$?
-        if [ $rc != 0 ]; then
-          rm -rf "${pidfile}"
+        if [ $rc -ne 0 ]; then
           break
         fi
-        kill "$pid"
-        sleep 1
+        kill "$pid" 2>/dev/null
       done
     fi
-    if [ -s "${pidfile}" ]; then
+    rc=$?
+    if [ $rc -ne 0 ]; then
       echo "failed."
       exit 1
     else
@@ -108,14 +98,14 @@ case "$1" in
   reload)
     checkrunning
     if [ $running = 1 ] && [ "$pid" != "" ]; then
-      echo -n "Reloading ${servicename}..."
+      echo -n "Reloading memcached..."
       kill -HUP "$pid"
       echo "done."
     fi
 
     ;;
   status)
-    echo -n "${servicename} is "
+    echo -n "memcached is "
     checkrunning
     if [ $running = 0 ]; then
       echo "not running."

--- a/src/bin/zmmilterctl
+++ b/src/bin/zmmilterctl
@@ -10,17 +10,13 @@ zmsetvars
 
 configfile=/opt/zextras/conf/localconfig.xml
 log4jfile=/opt/zextras/conf/milter.log4j.properties
-pidfile=${zimbra_log_directory}/milter.pid
-pid=""
 java="/opt/zextras/bin/zmjava"
 
 runcmd="${java} -Dlog4j.configurationFile=file:${log4jfile} -Dzimbra.home=\"/opt/zextras\" -Dzimbra.config=\"${configfile}\" \
    com.zimbra.cs.milter.MilterServer"
 
 getpid() {
-  if [ -f "${pidfile}" ]; then
-    pid=$(cat "${pidfile}")
-  fi
+  pid=$(pgrep -f '/opt/zextras/.*/java.*milter.MilterServer')
 }
 
 checkrunning() {
@@ -28,14 +24,7 @@ checkrunning() {
   if [ "$pid" = "" ]; then
     running=0
   else
-    kill -0 "$pid" 2>/dev/null
-    rc=$?
-    if [ $rc != 0 ]; then
-      pid=""
-      running=0
-    else
-      running=1
-    fi
+    running=1
   fi
 }
 
@@ -58,14 +47,8 @@ case "$1" in
     fi
 
     nohup sh -c "exec ${runcmd} 2>&1" >/opt/zextras/log/milter.out 2>&1 &
+    sleep 3
 
-    pid=$!
-    if [ "$pid" != 'x' ]; then
-      echo $pid >"$pidfile"
-    else
-      echo "failed."
-      exit 1
-    fi
     checkrunning
     if [ $running = 1 ]; then
       echo "done."
@@ -86,14 +69,13 @@ case "$1" in
         kill -0 "$pid" 2>/dev/null
         rc=$?
         if [ $rc -ne 0 ]; then
-          rm -rf "${pidfile}"
           break
         fi
-        kill "$pid"
-        sleep 1
       done
     fi
-    if [ -s "${pidfile}" ]; then
+    kill "$pid" 2>/dev/null
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
       echo "failed."
       exit 1
     else

--- a/src/bin/zmmytop
+++ b/src/bin/zmmytop
@@ -37,8 +37,12 @@ zmsetvars
 if [ -x "/opt/zextras/common/bin/mytop" ]; then
   if [ "$1" = "-r" ]; then
     shift
-    /opt/zextras/common/bin/mytop -u root -S "$mysql_socket" -p "$mysql_root_password" "$@"
+    /opt/zextras/common/bin/mytop \
+      -u root -S /run/carbonio/mysql.sock -p "$mysql_root_password" "$@"
   else
-    /opt/zextras/common/bin/mytop -u "$zimbra_mysql_user" -S "$mysql_socket" -p "$zimbra_mysql_password" "$@"
+    /opt/zextras/common/bin/mytop \
+      -u "$zimbra_mysql_user" \
+      -S /run/carbonio/mysql.sock \
+      -p "$zimbra_mysql_password" "$@"
   fi
 fi

--- a/src/bin/zmopendkimctl
+++ b/src/bin/zmopendkimctl
@@ -28,15 +28,15 @@ rewriteconfig() {
 
 checkrunning() {
   if pidof "${odk}" >/dev/null 2>&1; then
-    RUNNING=1
+    running=1
   else
-    RUNNING=0
+    running=0
   fi
 }
 
 start() {
   checkrunning
-  if [ $RUNNING = 0 ]; then
+  if [ $running = 0 ]; then
     if [ "$1" == "" ]; then
       rewriteconfig
     fi
@@ -54,7 +54,7 @@ start() {
 
 stop() {
   checkrunning
-  if [ $RUNNING = 0 ]; then
+  if [ $running = 0 ]; then
     echo "zmopendkimctl not running"
     exit 0
   else
@@ -72,7 +72,7 @@ stop() {
 status() {
   checkrunning
   echo -n "zmopendkimctl is "
-  if [ $RUNNING = 0 ]; then
+  if [ $running = 0 ]; then
     echo "not running."
     exit 1
   else

--- a/src/bin/zmplayredo
+++ b/src/bin/zmplayredo
@@ -26,16 +26,16 @@ for opt in "$@"; do
   fi
 done
 
-ropid=${zimbra_log_directory}/zmplayredo.pid
+pid=$(pgrep -f '/opt/zextras/.*/java.*redolog.util.PlaybackUtil')
 
 if [ $opth -eq 0 ]; then
   if isrunning; then
     echo "Error: mailboxd still running.  Stop mailboxd before running zmplayredo."
     exit 1
   fi
-  if [ -s "$ropid" ]; then
-    echo "Error: another instance of zmplayredo (pid=$(cat "$ropid")) is already running"
-    echo "       remove $ropid if this is not the case"
+  if [ "$pid" != "" ]; then
+    echo "Error: another instance of zmplayredo (pid=$pid) is already running"
+    echo "       remove $pid if this is not the case"
     exit 1
   fi
 fi
@@ -78,7 +78,6 @@ for opt in $mailboxd_java_options; do
   fi
 done
 
-echo $$ >"$ropid"
 # shellcheck disable=SC2086
 ${zimbra_java_home}/bin/java \
   ${xms_xmx_options} ${sanitized_options} \
@@ -87,5 +86,4 @@ ${zimbra_java_home}/bin/java \
   -classpath ${jardirs} \
   com.zimbra.cs.redolog.util.PlaybackUtil "$@"
 rc=$?
-rm -f "$ropid"
 exit $rc

--- a/src/bin/zmproxyctl
+++ b/src/bin/zmproxyctl
@@ -13,15 +13,11 @@ fi
 source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
-servicename=proxy
 configfile=/opt/zextras/conf/nginx.conf
-pidfile="${zimbra_log_directory}/nginx.pid"
 pid=""
 
 getpid() {
-  if [ -f "${pidfile}" ]; then
-    pid=$(cat "${pidfile}")
-  fi
+  pid=$(pgrep -f '/opt/zextras/.*/nginx.*conf')
 }
 
 checkrunning() {
@@ -29,12 +25,7 @@ checkrunning() {
   if [ "$pid" = "" ]; then
     running=0
   else
-    if ps --no-headers -p "$pid" -o cmd 2>/dev/null | grep nginx >/dev/null 2>&1; then
-      running=1
-    else
-      pid=""
-      running=0
-    fi
+    running=1
   fi
 }
 
@@ -46,9 +37,9 @@ case "$1" in
     fi
 
     checkrunning
-    echo -n "Starting ${servicename}..."
+    echo -n "Starting proxy..."
     if [ $running = 1 ]; then
-      echo "${servicename} is already running."
+      echo "proxy is already running."
       exit 0
     fi
     if [ "$2" = "" ]; then
@@ -97,19 +88,19 @@ case "$1" in
     ;;
   stop)
     checkrunning
-    echo -n "Stopping ${servicename}..."
+    echo -n "Stopping proxy..."
     if [ $running = 0 ]; then
-      echo "${servicename} is not running."
+      echo "proxy is not running."
       exit 0
     else
       /opt/zextras/common/sbin/nginx -c /opt/zextras/conf/nginx.conf -s stop
-      sleep 1
-    fi
-    if [ -s "${pidfile}" ]; then
-      echo "failed."
-      exit 1
-    else
-      echo "done."
+      rc=$?
+      if [ "$rc" -ne 0 ]; then
+        echo "failed."
+        exit 1
+      else
+        echo "done."
+      fi
     fi
     exit 0
     ;;
@@ -120,14 +111,14 @@ case "$1" in
   reload)
     checkrunning
     if [ $running = 1 ] && [ "$pid" != "" ]; then
-      echo -n "Reloading ${servicename}..."
+      echo -n "Reloading proxy..."
       /opt/zextras/common/sbin/nginx -c /opt/zextras/conf/nginx.conf -s reload
       echo "done."
     fi
 
     ;;
   status)
-    echo -n "${servicename} is "
+    echo -n "proxy is "
     checkrunning
     if [ $running = 0 ]; then
       echo "not running."

--- a/src/bin/zmsaslauthdctl
+++ b/src/bin/zmsaslauthdctl
@@ -14,16 +14,13 @@ source /opt/zextras/bin/zmshutil || exit 1
 zmsetvars
 
 pid=""
-pidfile="/opt/zextras/data/sasl2/state/saslauthd.pid"
 
 rewriteconfig() {
   /opt/zextras/libexec/configrewrite sasl >/dev/null 2>&1
 }
 
 getpid() {
-  if [ -f ${pidfile} ]; then
-    pid=$(cat ${pidfile})
-  fi
+  pid=$(pidof /opt/zextras/common/sbin/saslauthd)
 }
 
 checkrunning() {
@@ -31,12 +28,7 @@ checkrunning() {
   if [ "$pid" = "" ]; then
     running=0
   else
-    if ps --no-headers -p "$pid" -o cmd 2>/dev/null | grep saslauthd >/dev/null 2>&1; then
-      running=1
-    else
-      pid=""
-      running=0
-    fi
+    running=1
   fi
 }
 
@@ -51,7 +43,6 @@ case "$1" in
       echo "already running."
       exit 0
     fi
-    mkdir -p /opt/zextras/data/sasl2/state
     if [ "$2" = "" ]; then
       rewriteconfig
     fi
@@ -76,17 +67,16 @@ case "$1" in
     else
       echo -n "Stopping saslauthd..."
       for ((i = 0; i < 30; i++)); do
-        kill -0 "$pid" 2>/dev/null
+        echo "$pid" | xargs kill 2>/dev/null
         rc=$?
         if [ $rc -ne 0 ]; then
-          rm -rf "${pidfile}"
           break
         fi
-        kill "$pid"
+        echo "$pid" | xargs kill
         sleep 1
       done
     fi
-    if [ -s ${pidfile} ]; then
+    if [[ "${pid}" != "" ]]; then
       exit 1
     else
       echo "done."

--- a/src/bin/zmshutil
+++ b/src/bin/zmshutil
@@ -33,7 +33,7 @@ zmsetvars() {
 #
 # Check if a conditional expression is true.
 #
-zmassert() {
+assert() {
   if [ "$@" ]; then
     return
   fi

--- a/src/bin/zmstatctl
+++ b/src/bin/zmstatctl
@@ -84,7 +84,7 @@ sub getPidFiles() {
         my @pidfiles = readdir(DIR);
         foreach my $file (@pidfiles) {
             next
-              if ( $file =~ /zmstat-fd-real/ )
+              if ( $file =~ /fd-real/ )
               ;    # can't kill/test: running as root
             if ( $file =~ /\.pid$/ ) {
                 push( @pids, "$piddir/$file" );

--- a/src/bin/zmthrdump
+++ b/src/bin/zmthrdump
@@ -8,7 +8,7 @@
 use strict;
 use Getopt::Std;
 
-my $pid_file  = '/opt/zextras/log/zmmailboxd_java.pid';
+my $pid_file  = '/run/carbonio/zmmailboxd_java.pid';
 my $log_file  = '/opt/zextras/log/zmmailboxd.out';
 my $outhandle = \*STDOUT;
 my $timeout   = 25;

--- a/src/libexec/600.zimbra
+++ b/src/libexec/600.zimbra
@@ -6,7 +6,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
 PATH=/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/opt/zextras/bin:/opt/zextras/libexec
-SU="su - zextras -c "
 
 echo ""
 printf %s "Rotating log files:"
@@ -58,15 +57,8 @@ echo ""
 echo "Sending sighup to syslogd"
 systemctl kill -s HUP rsyslog.service >/dev/null 2>&1 || true
 
-if [ -f /opt/zextras/log/logswatch.pid ]; then
-  echo "Restarting zmlogswatch"
-  $SU "/opt/zextras/bin/zmlogswatchctl reload"
-fi
-if [ -f /opt/zextras/log/swatch.pid ]; then
-  echo "Restarting zmswatch"
-  $SU "/opt/zextras/bin/zmswatchctl reload"
-fi
-if [ -f /opt/zextras/log/nginx.pid ]; then
+pid=$(pgrep -f '/opt/zextras/.*/nginx.*conf')
+if [ "$pid" != "" ]; then
   echo "Sending USR1 to nginx"
-  kill -USR1 "$(head -1 /opt/zextras/log/nginx.pid)"
+  kill -USR1 "$pid"
 fi

--- a/src/libexec/carbonio
+++ b/src/libexec/carbonio
@@ -53,7 +53,7 @@ case "$1" in
     fi
     ;;
   reload | status)
-    carbonio_command $1
+    carbonio_command "$1"
     RETVAL=$?
     ;;
   *)

--- a/src/libexec/zmantispamdbinit
+++ b/src/libexec/zmantispamdbinit
@@ -13,12 +13,12 @@ sql_root_pw=$1
 #
 # Sanity checks
 #
-zmassert -x /opt/zextras/bin/antispam-mysqladmin
-zmassert -x /opt/zextras/bin/antispam-mysql
-zmassert -x /opt/zextras/bin/zmlocalconfig
-zmassert -x /opt/zextras/bin/zmantispamdbpasswd
-zmassert -x /opt/zextras/common/share/mysql/scripts/mysql_install_db
-zmassert -r /opt/zextras/data/amavisd/mysql/antispamdb.sql
+assert -x /opt/zextras/bin/antispam-mysqladmin
+assert -x /opt/zextras/bin/antispam-mysql
+assert -x /opt/zextras/bin/zmlocalconfig
+assert -x /opt/zextras/bin/zmantispamdbpasswd
+assert -x /opt/zextras/common/share/mysql/scripts/mysql_install_db
+assert -r /opt/zextras/data/amavisd/mysql/antispamdb.sql
 
 # Check if log directory exists.  If not, create.
 if [ ! -d "${zimbra_log_directory}" ]; then
@@ -45,10 +45,7 @@ echo "* Creating database in ${antispam_mysql_data_directory}"
 #
 # Start mysql server for antispam db
 #
-zmassert -d "$(dirname "${antispam_mysql_pidfile}")"
-if [ -f "${antispam_mysql_pidfile}" ]; then
-  pid=$(cat "${antispam_mysql_pidfile}")
-fi
+pid=$(pgrep -f '/opt/zextras/.*/mysqld.*conf/my.cnf')
 if [ "$pid" != "" ]; then
   kill -0 "$pid" 2>/dev/null
   rc=$?

--- a/src/libexec/zmantispammycnf
+++ b/src/libexec/zmantispammycnf
@@ -39,8 +39,7 @@ cat <<EOF
 
 basedir        = /opt/zextras/common
 datadir        = ${antispam_mysql_data_directory}
-socket         = ${antispam_mysql_socket}
-pid-file       = ${antispam_mysql_pidfile}
+socket         = /run/carbonio/antispam-mysql.sock
 bind-address   = 0.0.0.0
 port           = ${antispam_mysql_port}
 user           = ${antispam_mysql_user}
@@ -83,7 +82,6 @@ innodb_flush_log_at_trx_commit = 0
 [mysqld_safe]
 
 log-error    = ${zimbra_log_directory}/antispam-mysqld.log
-pid-file     = ${antispam_mysql_pidfile}
 
 
 EOF

--- a/src/libexec/zmconfigd
+++ b/src/libexec/zmconfigd
@@ -169,11 +169,6 @@ if len(sys.argv) > 1:
 		dt = time.clock()-t0
 		Log.logMsg(4, "%s completed in %.2f seconds" % (myConfig.progname,dt));
 		sys.exit(0)
-else:
-	if myState.isrunning():
-		Log.logMsg(0, "zmconfigd already running, exiting")
-	else:
-		myState.writepid()
 
 # Removed this to speed up startup at the cost of some slowdown in the first fetch
 # We don't really care about this thread, but should make sure it's done

--- a/src/libexec/zmdbintegrityreport
+++ b/src/libexec/zmdbintegrityreport
@@ -68,7 +68,7 @@ sub usage {
 
 sub checkDbs() {
   my $mysql_root_passwd = getLocalConfig("mysql_root_password");
-  my $mysql_socket = getLocalConfig("mysql_socket") || "/opt/zextras/db/mysql.sock";
+  my $mysql_socket = "/run/carbonio/mysql.sock";
   my $mysql_mycnf = getLocalConfig("mysql_mycnf") || "/opt/zextras/conf/my.cnf";
 
   prepareDataDirectoryForChecks($mysql_mycnf);
@@ -83,7 +83,7 @@ sub checkDbs() {
     exit 1;
   }
   $cmd .= " --defaults-file=${mysql_mycnf}";
-  $cmd .= " -S ${mysql_socket}";
+  $cmd .= " -S /run/carbonio/mysql.sock";
   $cmd .= " -A";
   $cmd .= " -C" unless $options{o};
   $cmd .= " -s" unless $debug;

--- a/src/libexec/zmdiaglog
+++ b/src/libexec/zmdiaglog
@@ -42,7 +42,7 @@ $DLOGDIR = "zmdiaglog-$ZMHOSTNAME."
   . strftime( "%Y%m%d-%H%M%S", localtime() ) . "."
   . $$;
 $DEFAULT_TIMEOUT                    = 120;
-$PID_FILE                           = '/opt/zextras/log/zmmailboxd_java.pid';
+$PID_FILE                           = '/run/carbonio/zmmailboxd_java.pid';
 $JMAP                               = '/opt/zextras/common/bin/jmap';
 $JAVA                               = '/opt/zextras/common/lib/jvm/java/bin/java';
 $JINFO                              = '/opt/zextras/common/lib/jvm/java/bin/jinfo';

--- a/src/libexec/zmfixperms
+++ b/src/libexec/zmfixperms
@@ -383,15 +383,6 @@ if [ -d /opt/zextras/common/share/database ]; then
   chown -R ${zextras_user}:${zextras_group} /opt/zextras/data/cbpolicyd
 fi
 
-if [ -x /opt/zextras/common/sbin/saslauthd ]; then
-  printMsg "Fixing ownership and permissions on /opt/zextras/data/sasl2/state"
-  if [ ! -d /opt/zextras/data/sasl2/state ]; then
-    mkdir -p /opt/zextras/data/sasl2/state
-  fi
-  chown -R ${zextras_user}:${zextras_group} /opt/zextras/data/sasl2/state
-  chmod 755 /opt/zextras/data/sasl2/state
-fi
-
 if [ -x /opt/zextras/common/bin/altermime ]; then
   if [ ! -d "/opt/zextras/data/altermime" ]; then
     mkdir -p /opt/zextras/data/altermime

--- a/src/libexec/zmjavawatch
+++ b/src/libexec/zmjavawatch
@@ -82,7 +82,7 @@ GetOptions("help" => \$ARG{HELP},
 	   "thread-dump-delay=i" => \$ARG{TWAIT},
 	   "thread-dump-file=s" => \$ARG{LOG}) || usage();
 
-my $DEFAULT_PID = qx(cat '/opt/zextras/log/zmmailboxd_java.pid');
+my $DEFAULT_PID = qx(cat '/run/carbonio/zmmailboxd_java.pid');
 chomp($DEFAULT_PID);
 usage() if (defined $ARG{HELP});
 $ARG{PID} = $DEFAULT_PID if (!defined $ARG{PID});

--- a/src/libexec/zmlogprocess
+++ b/src/libexec/zmlogprocess
@@ -22,7 +22,7 @@ use vars qw($logger_directory $log_file);
 # Exit if software-only node.
 exit(0) unless (-f '/opt/zextras/conf/localconfig.xml');
 
-my $pid_file = "/opt/zextras/log/zmlogprocess.pid";
+my $pid_file = "/run/carbonio/zmlogprocess.pid";
 my $state_file = "/opt/zextras/log/zmlogprocess.state";
 $logger_directory = getLocalConfig("logger_data_directory");
 $log_file = '/var/log/carbonio.log';

--- a/src/libexec/zmmycnf
+++ b/src/libexec/zmmycnf
@@ -44,8 +44,8 @@ cat <<EOF
 
 basedir        = /opt/zextras/common
 datadir        = ${mysql_data_directory}
-socket         = ${mysql_socket}
-pid-file       = ${mysql_pidfile}
+socket         = /run/carbonio/mysql.sock
+pid-file       = /run/carbonio/mysql.pid
 bind-address   = ${mysql_bind_address}
 port           = ${mysql_port}
 user           = ${zimbra_mysql_user}
@@ -89,7 +89,7 @@ max_allowed_packet             = 16777216
 [mysqld_safe]
 
 log-error      = ${zimbra_log_directory}/mysqld.log
-pid-file     = ${mysql_pidfile}
+pid-file     = /run/carbonio/mysql.pid
 
 
 EOF

--- a/src/libexec/zmmyinit
+++ b/src/libexec/zmmyinit
@@ -25,14 +25,14 @@ zmsetvars -f
 #
 # Sanity checks
 #
-zmassert -x /opt/zextras/libexec/zmmycnf
-zmassert -x /opt/zextras/bin/mysqladmin
-zmassert -x /opt/zextras/bin/mysql
-zmassert -x /opt/zextras/bin/zmlocalconfig
-zmassert -x /opt/zextras/bin/zmmypasswd
-zmassert -x /opt/zextras/common/share/mysql/scripts/mysql_install_db
-zmassert -r "${zimbra_db_directory}/db.sql"
-zmassert -r "${zimbra_db_directory}/versions-init.sql"
+assert -x /opt/zextras/libexec/zmmycnf
+assert -x /opt/zextras/bin/mysqladmin
+assert -x /opt/zextras/bin/mysql
+assert -x /opt/zextras/bin/zmlocalconfig
+assert -x /opt/zextras/bin/zmmypasswd
+assert -x /opt/zextras/common/share/mysql/scripts/mysql_install_db
+assert -r "${zimbra_db_directory}/db.sql"
+assert -r "${zimbra_db_directory}/versions-init.sql"
 
 for opt in "$@"; do
   case "$opt" in

--- a/src/libexec/zmqueuelog
+++ b/src/libexec/zmqueuelog
@@ -25,8 +25,8 @@ clearPid();
 exit 0;
 
 sub checkPid {
-	if (-f "/opt/zextras/log/zmqueuelog.pid") {
-		my $P = qx(cat /opt/zextras/log/zmqueuelog.pid);
+	if (-f "/run/carbonio/zmqueuelog.pid") {
+		my $P = qx(cat /run/carbonio/zmqueuelog.pid);
 		chomp $P;
 		if ($P ne "") {
       system("kill -0 $P 2> /dev/null");
@@ -36,11 +36,11 @@ sub checkPid {
       }
 		}
 	}
-	qx(echo $$ > "/opt/zextras/log/zmqueuelog.pid");
+	qx(echo $$ > "/run/carbonio/zmqueuelog.pid");
 }
 
 sub clearPid {
-	unlink ("/opt/zextras/log/zmqueuelog.pid");
+	unlink ("/run/carbonio/zmqueuelog.pid");
 }
 
 sub logQueue {

--- a/src/libexec/zmresetmysqlpassword
+++ b/src/libexec/zmresetmysqlpassword
@@ -16,11 +16,11 @@ zmsetvars -f
 #
 # Sanity checks
 #
-zmassert -x /opt/zextras/common/bin/mysqladmin
-zmassert -x /opt/zextras/common/bin/mysql
-zmassert -x /opt/zextras/bin/zmlocalconfig
-zmassert -x /opt/zextras/bin/zmcontrol
-zmassert -r "${zimbra_db_directory}/db.sql"
+assert -x /opt/zextras/common/bin/mysqladmin
+assert -x /opt/zextras/common/bin/mysql
+assert -x /opt/zextras/bin/zmlocalconfig
+assert -x /opt/zextras/bin/zmcontrol
+assert -r "${zimbra_db_directory}/db.sql"
 if [ ! -x /opt/zextras/common/bin/mysql ]; then
   echo "Mysql not found on this host."
   exit 1

--- a/src/libexec/zmstat-allprocs
+++ b/src/libexec/zmstat-allprocs
@@ -283,7 +283,7 @@ if (!$opts_good) {
 	print STDERR "\n";
 	usage();
 }
-createPidFile("zmstat-allprocs.pid");
+createPidFile("allprocs.pid");
 $SIG{HUP} = \&sighup;
 
 $date = getDate();

--- a/src/libexec/zmstat-convertd
+++ b/src/libexec/zmstat-convertd
@@ -91,7 +91,7 @@ sub collect_stats($$$) {
 }
 
 sub get_convertd_pid {
-    open(PID, "</opt/zextras/log/convertd.pid") || die "cannot open convertd.pid: $!";
+    open(PID, "</run/carbonio/convertd.pid") || die "cannot open convertd.pid: $!";
     chomp(my $pid = <PID>);
     close(PID);
     $pid;
@@ -235,7 +235,7 @@ if (!$opts_good) {
 	print STDERR "\n";
 	usage();
 }
-createPidFile("zmstat-convertd.pid");
+createPidFile("convertd.pid");
 $SIG{HUP} = \&sighup;
 
 $date = getDate();

--- a/src/libexec/zmstat-cpu
+++ b/src/libexec/zmstat-cpu
@@ -169,7 +169,7 @@ if ($CONSOLE) {
     $LOGFILE = '-';
 }
 
-createPidFile('zmstat-cpu.pid');
+createPidFile('cpu.pid');
 
 $SIG{HUP} = \&sighup;
 

--- a/src/libexec/zmstat-df
+++ b/src/libexec/zmstat-df
@@ -99,7 +99,7 @@ if (!$opts_good) {
     print STDERR "\n";
     usage();
 }
-createPidFile('zmstat-df.pid');
+createPidFile('df.pid');
 
 my $date = getDate();
 if ($CONSOLE) {

--- a/src/libexec/zmstat-fd
+++ b/src/libexec/zmstat-fd
@@ -25,7 +25,7 @@ my ($zuid,$zgid) = (getpwnam($zuser))[2,3];
 
 if (@ARGV > 0 && $ARGV[0] eq 'stop') {
 	my $dir = getPidFileDir();
-	my $pidFile = "$dir/zmstat-fd-real.pid";
+	my $pidFile = "$dir/fd-real.pid";
 	my $pid = readPidFile($pidFile);
     if (!kill(0, $pid)) {
         unlink($pidFile);
@@ -38,14 +38,14 @@ if (@ARGV > 0 && $ARGV[0] eq 'stop') {
 }
 if (@ARGV > 0 && $ARGV[0] eq 'rotate') {
 	my $dir = getPidFileDir();
-	my $pidFile = "$dir/zmstat-fd-real.pid";
+	my $pidFile = "$dir/fd-real.pid";
 	my $pid = readPidFile($pidFile);
 	kill(1, $pid);
 }
 
 if ($< != 0) {
     Zimbra::Mon::Zmstat::userCheck();
-    createPidFile('zmstat-fd.pid');
+    createPidFile('fd.pid');
     $SIG{TERM} = sub {
     	system("sudo /opt/zextras/libexec/zmstat-fd stop");
     };
@@ -182,7 +182,7 @@ unless ($match) {
   exit(1);
 }
 
-createPidFile('zmstat-fd-real.pid');
+createPidFile('fd-real.pid');
 
 my $date = getDate();
 if ($CONSOLE) {

--- a/src/libexec/zmstat-io
+++ b/src/libexec/zmstat-io
@@ -163,7 +163,7 @@ if ($xtended) {
     $iostatOpts .= ' -x';
 }
 
-createPidFile( $xtended ? 'zmstat-io-x.pid' : 'zmstat-io.pid' );
+createPidFile( $xtended ? 'io-x.pid' : 'io.pid' );
 
 $SIG{HUP} = \&sighup;
 

--- a/src/libexec/zmstat-ldap
+++ b/src/libexec/zmstat-ldap
@@ -120,7 +120,7 @@ if ($CONSOLE) {
     $LOGFILE = '-';
 }
 
-createPidFile('zmstat-ldap.pid');
+createPidFile('ldap.pid');
 
 $SIG{HUP} = \&sighup;
 

--- a/src/libexec/zmstat-mtaqueue
+++ b/src/libexec/zmstat-mtaqueue
@@ -92,7 +92,7 @@ if ($CONSOLE) {
     $LOGFILE = '-';
 }
 
-createPidFile('zmstat-mtaqueue.pid');
+createPidFile('mtaqueue.pid');
 
 $SIG{HUP} = \&sighup;
 

--- a/src/libexec/zmstat-mysql
+++ b/src/libexec/zmstat-mysql
@@ -98,7 +98,7 @@ if ($CONSOLE) {
     $LOGFILE = '-';
 }
 
-createPidFile('zmstat-mysql.pid');
+createPidFile('mysql.pid');
 
 local $SIG{__WARN__} = \&Carp::cluck;
 

--- a/src/libexec/zmstat-nginx
+++ b/src/libexec/zmstat-nginx
@@ -92,7 +92,7 @@ sub collect_stats($$$) {
 
 sub get_nginx_pid {
     my $pid = 0;
-    if (open(PID, "</opt/zextras/log/nginx.pid")) {
+    if (open(PID, "</run/carbonio/nginx.pid")) {
         chomp($pid = <PID>);
         close(PID);
     } else {
@@ -246,7 +246,7 @@ if (!$opts_good) {
 	print STDERR "\n";
 	usage();
 }
-createPidFile("zmstat-nginx.pid");
+createPidFile("nginx.pid");
 $SIG{HUP} = \&sighup;
 
 $date = getDate();

--- a/src/libexec/zmstat-proc
+++ b/src/libexec/zmstat-proc
@@ -179,7 +179,7 @@ sub getMailboxProcess() {
 # Use this if mysqld is a single multi-threaded process. (dynamically linked build)
 sub getMysqlProcess() {
     my $zimbraHome = "/opt/zextras";
-    my $ps         = qx(cat $zimbraHome/db/mysql.pid);
+    my $ps         = qx(cat /run/carbonio/mysql.pid);
     chomp($ps) if ( defined($ps) );
     my @ret = ( { 'pid' => $ps } );
     return @ret;
@@ -496,7 +496,7 @@ if ($CONSOLE) {
     $LOGFILE = '-';
 }
 
-createPidFile('zmstat-proc.pid');
+createPidFile('proc.pid');
 
 local $SIG{__WARN__} = \&Carp::cluck;
 

--- a/src/libexec/zmstat-vm
+++ b/src/libexec/zmstat-vm
@@ -159,7 +159,7 @@ if ($CONSOLE) {
     $LOGFILE = '-';
 }
 
-createPidFile('zmstat-vm.pid');
+createPidFile('vm.pid');
 
 $SIG{HUP} = \&sighup;
 

--- a/src/libexec/zmstatuslog
+++ b/src/libexec/zmstatuslog
@@ -18,7 +18,7 @@ exit(0) unless (-f "/opt/zextras/conf/localconfig.xml");
 
 $SIG{ALRM} = \&catchAlarm;
 
-my $pidFile="/opt/zextras/log/zmstatuslog.pid";
+my $pidFile="/run/carbonio/zmstatuslog.pid";
 
 my $TIMEOUT=60;
 my $DFCMD;


### PR DESCRIPTION
The purpose of this PR is to move pidfiles into `/run/carbonio` folder, allowing the usage of persistance for 
- `/opt/zextras/log` 
- `/opt/zextras/zmstat`
- `/opt/zextras/data`

and ensuring a more robust and reliable processes supervisioning (both for systemd and zmcontrol).

Notes:
`zmcontrol` and all related scripts now evaluate the status of processes without relying on `.pid` files. This also ensures a transparent migration to the new `/run/carbonio` folder

Related PRs:
- [ ] https://github.com/zextras/carbonio-core/pull/72
- [ ] https://github.com/zextras/carbonio-mailbox/pull/510
- [ ] https://github.com/zextras/carbonio-freshclam/pull/5
- [ ] https://github.com/zextras/carbonio-amavis/pull/13
- [ ] https://github.com/zextras/carbonio-thirds/pull/33
- [ ] https://github.com/zextras/carbonio-proxy/pull/120

