### PR TITLE
feat: [CO-1343] Add LDAP module config update script

### DIFF
--- a/src/libexec/ldapmoduleconfupdate
+++ b/src/libexec/ldapmoduleconfupdate
@@ -12,31 +12,31 @@ BACKUP_DIR="/opt/zextras/data/ldap-post-install-backup/"
 BACKUP_MODULE_CONF_FILE="$BACKUP_DIR/cn=module{0}.ldif.bak"
 
 backup_module_config() {
-    echo "* Creating backup of module config file at $BACKUP_MODULE_CONF_FILE"
-    su - zextras -c "mkdir -p $BACKUP_DIR"
-    cp "$TARGET_MODULE_CONF_FILE" "$BACKUP_MODULE_CONF_FILE"
+  echo "* Creating backup of module config file at $BACKUP_MODULE_CONF_FILE"
+  su - zextras -c "mkdir -p $BACKUP_DIR"
+  cp "$TARGET_MODULE_CONF_FILE" "$BACKUP_MODULE_CONF_FILE"
 }
 
 update_module_config() {
-    echo "* Updating module config $TARGET_MODULE_CONF_FILE"
-    cp "$SOURCE_MODULE_CONF_FILE" "$TARGET_MODULE_CONF_FILE"
+  echo "* Updating module config $TARGET_MODULE_CONF_FILE"
+  cp "$SOURCE_MODULE_CONF_FILE" "$TARGET_MODULE_CONF_FILE"
 }
 
 main() {
-    if [ ! -f "$TARGET_MODULE_CONF_FILE" ]; then
-        echo "Error: Target module config file $TARGET_MODULE_CONF_FILE does not exist."
-        exit 1
-    fi
+  if [ ! -f "$TARGET_MODULE_CONF_FILE" ]; then
+    echo "Error: Target module config file $TARGET_MODULE_CONF_FILE does not exist."
+    exit 1
+  fi
 
-    if [ ! -f "$SOURCE_MODULE_CONF_FILE" ]; then
-        echo "Error: Source module config file $SOURCE_MODULE_CONF_FILE does not exist."
-        exit 1
-    fi
+  if [ ! -f "$SOURCE_MODULE_CONF_FILE" ]; then
+    echo "Error: Source module config file $SOURCE_MODULE_CONF_FILE does not exist."
+    exit 1
+  fi
 
-    if ! diff "$TARGET_MODULE_CONF_FILE" "$SOURCE_MODULE_CONF_FILE" > /dev/null; then
-        backup_module_config
-        update_module_config
-    fi
+  if ! diff "$TARGET_MODULE_CONF_FILE" "$SOURCE_MODULE_CONF_FILE" >/dev/null; then
+    backup_module_config
+    update_module_config
+  fi
 }
 
 main

--- a/src/libexec/ldapmoduleconfupdate
+++ b/src/libexec/ldapmoduleconfupdate
@@ -4,11 +4,39 @@
 #
 # SPDX-License-Identifier: GPL-2.0-only
 
+set -e
+
 TARGET_MODULE_CONF_FILE="/opt/zextras/data/ldap/config/cn=config/cn=module{0}.ldif"
 SOURCE_MODULE_CONF_FILE="/opt/zextras/common/etc/openldap/zimbra/config/cn=config/cn=module{0}.ldif"
+BACKUP_DIR="/opt/zextras/data/ldap-post-install-backup/"
+BACKUP_FILE="$BACKUP_DIR/cn=module{0}.ldif.bak"
 
-# update module conf if required
-if ! diff "$TARGET_MODULE_CONF_FILE" "$SOURCE_MODULE_CONF_FILE" > /dev/null; then
+backup_config() {
+    echo "* Creating backup of module config file at $BACKUP_FILE"
+    su - zextras -c "mkdir -p $BACKUP_DIR"
+    cp "$TARGET_MODULE_CONF_FILE" "$BACKUP_FILE"
+}
+
+update_config() {
     echo "* Updating module config $TARGET_MODULE_CONF_FILE"
     cp "$SOURCE_MODULE_CONF_FILE" "$TARGET_MODULE_CONF_FILE"
-fi
+}
+
+main() {
+    if [ ! -f "$TARGET_MODULE_CONF_FILE" ]; then
+        echo "Error: Target module config file $TARGET_MODULE_CONF_FILE does not exist."
+        exit 1
+    fi
+
+    if [ ! -f "$SOURCE_MODULE_CONF_FILE" ]; then
+        echo "Error: Source module config file $SOURCE_MODULE_CONF_FILE does not exist."
+        exit 1
+    fi
+
+    if ! diff "$TARGET_MODULE_CONF_FILE" "$SOURCE_MODULE_CONF_FILE" > /dev/null; then
+        backup_config
+        update_config
+    fi
+}
+
+main

--- a/src/libexec/ldapmoduleconfupdate
+++ b/src/libexec/ldapmoduleconfupdate
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+TARGET_MODULE_CONF_FILE="/opt/zextras/data/ldap/config/cn=config/cn=module{0}.ldif"
+SOURCE_MODULE_CONF_FILE="/opt/zextras/common/etc/openldap/zimbra/config/cn=config/cn=module{0}.ldif"
+
+# update module conf if required
+if ! diff "$TARGET_MODULE_CONF_FILE" "$SOURCE_MODULE_CONF_FILE" > /dev/null; then
+    echo "* Updating module config $TARGET_MODULE_CONF_FILE"
+    cp "$SOURCE_MODULE_CONF_FILE" "$TARGET_MODULE_CONF_FILE"
+fi

--- a/src/libexec/ldapmoduleconfupdate
+++ b/src/libexec/ldapmoduleconfupdate
@@ -33,7 +33,7 @@ main() {
     exit 1
   fi
 
-  if ! diff "$TARGET_MODULE_CONF_FILE" "$SOURCE_MODULE_CONF_FILE" >/dev/null; then
+  if ! cmp -s "$TARGET_MODULE_CONF_FILE" "$SOURCE_MODULE_CONF_FILE"; then
     backup_module_config
     update_module_config
   fi

--- a/src/libexec/ldapmoduleconfupdate
+++ b/src/libexec/ldapmoduleconfupdate
@@ -9,15 +9,15 @@ set -e
 TARGET_MODULE_CONF_FILE="/opt/zextras/data/ldap/config/cn=config/cn=module{0}.ldif"
 SOURCE_MODULE_CONF_FILE="/opt/zextras/common/etc/openldap/zimbra/config/cn=config/cn=module{0}.ldif"
 BACKUP_DIR="/opt/zextras/data/ldap-post-install-backup/"
-BACKUP_FILE="$BACKUP_DIR/cn=module{0}.ldif.bak"
+BACKUP_MODULE_CONF_FILE="$BACKUP_DIR/cn=module{0}.ldif.bak"
 
-backup_config() {
-    echo "* Creating backup of module config file at $BACKUP_FILE"
+backup_module_config() {
+    echo "* Creating backup of module config file at $BACKUP_MODULE_CONF_FILE"
     su - zextras -c "mkdir -p $BACKUP_DIR"
-    cp "$TARGET_MODULE_CONF_FILE" "$BACKUP_FILE"
+    cp "$TARGET_MODULE_CONF_FILE" "$BACKUP_MODULE_CONF_FILE"
 }
 
-update_config() {
+update_module_config() {
     echo "* Updating module config $TARGET_MODULE_CONF_FILE"
     cp "$SOURCE_MODULE_CONF_FILE" "$TARGET_MODULE_CONF_FILE"
 }
@@ -34,8 +34,8 @@ main() {
     fi
 
     if ! diff "$TARGET_MODULE_CONF_FILE" "$SOURCE_MODULE_CONF_FILE" > /dev/null; then
-        backup_config
-        update_config
+        backup_module_config
+        update_module_config
     fi
 }
 


### PR DESCRIPTION
This script will run during the post-installation hook of the **carbonio-directory-server** package upon upgrades. 

Its purpose is to **ensure that the LDAP module configuration is updated whenever modifications are applied to the modules loaded by carbonio-openldap**.

The decision to include this script here, rather than directly in the carbonio-directory-server package, is based on historical reasons. Additionally, separating this script helps prevent code duplication across different distribution-specific post-installation instructions in the PKGBUILD file.

**Linked PRs:**
- https://github.com/zextras/carbonio-mailbox/pull/548
- https://github.com/zextras/carbonio-core/pull/75