### PR TITLE
fix: use only carbonio-advanced-cli classpath to run the cli

### DIFF
--- a/src/bin/carbonio
+++ b/src/bin/carbonio
@@ -36,7 +36,7 @@ call_cli() {
       "$@"
   else
     exec /opt/zextras/bin/zmjava \
-      -cp "/opt/zextras/mailbox/jars/*:${carbonio_cli_path}/*" \
+      -cp "${carbonio_cli_path}/*" \
       -Xmx128m com.zextras.cli.AdvancedCLI \
       --columns "$TTY_COLS" \
       "$@"


### PR DESCRIPTION
Once we merge:

https://github.com/zextras/carbonio-advanced-cli/pull/80

it should be possible to run carbonio-advanced-cli using only `/usr/share/carbonio-advanced-cli/*` as classpath