### PR TITLE
fix: trainsa.sh: missing space prevents removal of temporary directories

### DIFF
--- a/src/bin/trainsa.sh
+++ b/src/bin/trainsa.sh
@@ -135,7 +135,7 @@ if [ "$1" = "--cleanup" ]; then
   if [ "${zmtrainsa_cleanup_host}" = "true" ]; then
     timestampit "Starting spam/ham cleanup"
     mydir=$(mktmpdir cleanup)
-    /opt/zextras/libexec/zmspamextract "${spam_account}" -o "${mydir}"-d
+    /opt/zextras/libexec/zmspamextract "${spam_account}" -o "${mydir}" -d
     /opt/zextras/libexec/zmspamextract "${ham_account}" -o "${mydir}" -d
     rm -rf "${mydir}"
     timestampit "Finished spam/ham cleanup"


### PR DESCRIPTION
@M0Rf30 Through a typo introduced in 366ca364ea33e03b4382b727ebfb0ed68e597831 temporary directories for the SA training operation are created with a trailing `-d` in the name, while the script attempts to remove temporary directories without it at the end of the operation.
Result: temporary directories survive each operation.