### PR TITLE
refactor: [CO-1767] remove web.xml and mailbox restart on change

### DIFF
--- a/conf/configd.cf
+++ b/conf/configd.cf
@@ -331,10 +331,6 @@ SECTION mailbox
 	REWRITE conf/spnego_java_options.in conf/spnego_java_options
 	RESTART mailboxd
 
-SECTION service
-	REWRITE conf/web.xml.in conf/web.xml
-	RESTART mailboxd
-
 SECTION proxy
 	LOCAL ldap_url
 	MAPLOCAL zimbraSSLDHParam


### PR DESCRIPTION
web.xml has been removed from carbonio-appserver.
This causes some warnings in zmconfigd:

`File "/opt/zextras/common/lib/jylibs/state.py", line 758, in rewriteConfig     for line in open(fr).readlines():`
`zmconfigd[7367]: Rewrite failed: [Errno 2] No such file or directory: '/opt/zextras/conf/web.xml.in' ([Errno 2] No such file or directory: '/opt/zextras/conf/web.xml.in')`