### PR TITLE
fix(CO-3401): zmthrdump fails without -p option due to pgrep returning multiple PIDs

### DIFF
--- a/src/bin/thrdump.pl
+++ b/src/bin/thrdump.pl
@@ -83,12 +83,12 @@ if ( exists $opts{'p'} ) {
     usage() if ( !defined($pid) || $pid !~ /^\d+$/ );
 }
 else {
-    $pid = qx(pgrep -f '/opt/zextras/.*/java.*mailboxd');
+    $pid = qx(pgrep -o -f '/opt/zextras/.*/java.*mailboxd');
     chomp($pid);
 }
 
-if ( !kill( 0, $pid ) ) {
-    print STDERR "zmthrdump: pid $pid not found\n";
+if ( !defined($pid) || $pid !~ /^\d+$/ || !kill( 0, $pid ) ) {
+    print STDERR "zmthrdump: unable to determine mailboxd pid\n";
     exit 1;
 }
 

--- a/src/libexec/diaglog.pl
+++ b/src/libexec/diaglog.pl
@@ -135,7 +135,7 @@ sub get_pid() {
     my $pid = 0;
     if ( !$pid ) {
         eval {
-            $pid = qx(pgrep -f '/opt/zextras/.*/java.*mailboxd');
+            $pid = qx(pgrep -o -f '/opt/zextras/.*/java.*mailboxd');
             chomp($pid);
         };
         if ( !$pid ) {

--- a/src/libexec/javawatch.pl
+++ b/src/libexec/javawatch.pl
@@ -82,7 +82,7 @@ GetOptions("help" => \$ARG{HELP},
 	   "thread-dump-delay=i" => \$ARG{TWAIT},
 	   "thread-dump-file=s" => \$ARG{LOG}) || usage();
 
-my $DEFAULT_PID = qx(pgrep -f '/opt/zextras/.*/java.*mailboxd');
+my $DEFAULT_PID = qx(pgrep -o -f '/opt/zextras/.*/java.*mailboxd');
 chomp($DEFAULT_PID);
 usage() if (defined $ARG{HELP});
 $ARG{PID} = $DEFAULT_PID if (!defined $ARG{PID});

--- a/src/libexec/stat-fd.pl
+++ b/src/libexec/stat-fd.pl
@@ -88,7 +88,7 @@ sub get_mboxd_pid() {
     my $pid = 0;
     if ( !$pid ) {
         eval {
-            $pid = qx(pgrep -f '/opt/zextras/.*/java.*mailboxd');
+            $pid = qx(pgrep -o -f '/opt/zextras/.*/java.*mailboxd');
             chomp($pid);
         };
         if ( !$pid ) {


### PR DESCRIPTION
pgrep -f matches the invoking shell process (e.g. su) in addition to the actual Java process, resulting in a multi-line non-numeric PID. Adding -o (oldest) ensures only the real mailboxd process is returned.

Refs: CO-3401