### PR TITLE
feat: remove java.library.path after JNI native library removal

### DIFF
--- a/src/bin/java.sh
+++ b/src/bin/java.sh
@@ -11,14 +11,9 @@ zmsetvars -f
 
 java_options="-XX:ErrorFile=/opt/zextras/log"
 
-if [ "${zimbra_zmjava_java_library_path}" = "" ]; then
-  zimbra_zmjava_java_library_path=/opt/zextras/lib
-fi
-
 # shellcheck disable=SC2086
 exec "${zimbra_java_home}/bin/java" ${java_options} \
   -client ${zimbra_zmjava_options} \
   -Dzimbra.home=/opt/zextras \
-  -Djava.library.path=${zimbra_zmjava_java_library_path} \
   -classpath "/opt/zextras/mailbox/jars/*" \
   "$@"

--- a/src/bin/javaext.sh
+++ b/src/bin/javaext.sh
@@ -25,10 +25,6 @@ done
 
 java_options="-XX:ErrorFile=/opt/zextras/log"
 
-if [ "${zimbra_zmjava_java_library_path}" = "" ]; then
-  zimbra_zmjava_java_library_path=/opt/zextras/lib
-fi
-
 if [ "${zimbra_zmjava_java_ext_dirs}" = "" ]; then
   zimbra_zmjava_java_ext_dirs=${JRE_EXT_DIR}:/opt/zextras/mailbox/jars:${ZIMBRA_EXT_DIR}
 fi
@@ -37,6 +33,5 @@ fi
 exec "${zimbra_java_home}/bin/java" ${java_options} \
   -client ${zimbra_zmjava_options} \
   -Dzimbra.home=/opt/zextras \
-  -Djava.library.path=${zimbra_zmjava_java_library_path} \
   -Djava.ext.dirs=${zimbra_zmjava_java_ext_dirs} \
   "$@"

--- a/src/bin/localconfig.sh
+++ b/src/bin/localconfig.sh
@@ -19,5 +19,5 @@ java="${ROOT}/common/bin/java"
 CP="${ROOT}/mailbox/jars/*"
 
 exec ${java} -client -cp "$CP" \
-  -Djava.library.path=${ROOT}/lib -Dzimbra.home="${ROOT}" \
+  -Dzimbra.home="${ROOT}" \
   com.zimbra.cs.localconfig.LocalConfigCLI "$@"

--- a/src/bin/mailboxdctl.sh
+++ b/src/bin/mailboxdctl.sh
@@ -83,7 +83,6 @@ case "$1" in
       -Xms${javaXms}m \
       -Xmx${javaXmx}m \
       -Djava.io.tmpdir=/opt/zextras/mailboxd/work \
-      -Djava.library.path=/opt/zextras/lib \
       -Dzimbra.config=/opt/zextras/conf/localconfig.xml \
       -cp /opt/zextras/mailbox/jars/mailbox.jar:/opt/zextras/mailbox/jars/* \
       com.zextras.mailbox.Mailbox &>>/opt/zextras/log/zmmailboxd.out &

--- a/src/bin/playredo.sh
+++ b/src/bin/playredo.sh
@@ -82,7 +82,6 @@ done
 ${zimbra_java_home}/bin/java \
   ${xms_xmx_options} ${sanitized_options} \
   -Dzimbra.config=/opt/zextras/conf/localconfig.xml \
-  -Djava.library.path=/opt/zextras/lib \
   -classpath ${jardirs} \
   com.zimbra.cs.redolog.util.PlaybackUtil "$@"
 rc=$?

--- a/src/bin/systemd-envscript.sh
+++ b/src/bin/systemd-envscript.sh
@@ -4,15 +4,8 @@
 eval "$(/opt/zextras/common/bin/java \
   -client \
   -cp '/opt/zextras/mailbox/jars/*' \
-  -Djava.library.path=/opt/zextras/lib \
   -Dzimbra.home=/opt/zextras \
   com.zimbra.cs.localconfig.LocalConfigCLI -q -m shell || true)"
-
-# java
-
-if [[ "${zimbra_zmjava_java_library_path}" = "" ]]; then
-  zimbra_zmjava_java_library_path=/opt/zextras/lib
-fi
 
 # openldap
 # Check for ldap_bind_url first (can contain multiple URLs), then fall back to ldap_url
@@ -68,7 +61,6 @@ fi
   echo "bind_url=${bind_url}"
   echo "configd_listen_port=${zmconfigd_listen_port}"
   echo "configd_rewrite_timeout=${zimbra_configrewrite_timeout}"
-  echo "java_library_path=${zimbra_zmjava_java_library_path}"
   echo "java_options=${zimbra_zmjava_options}"
   echo "java_xms=${javaXms}"
   echo "java_xmx=${javaXmx}"

--- a/src/libexec/jsprecompile.sh
+++ b/src/libexec/jsprecompile.sh
@@ -42,7 +42,6 @@ done
 java_cmd="${zimbra_java_home}/bin/java \
   -client -Xmx256m \
   -Dzimbra.home=/opt/zextras \
-  -Djava.library.path=/opt/zextras/lib \
   -classpath ${jspc_class_path}:${class_path}"
 
 if [ -d "${jspc_build_dir}" ]; then


### PR DESCRIPTION
## Summary

- Removes `-Djava.library.path` from all Java wrapper scripts and systemd env generator
- Removes `java_library_path` export from `systemd-envscript.sh`
- The JNI native library (`libznative.so`) has been replaced by Java FFM + stdlib in carbonio-mailbox ([PR #980](https://github.com/zextras/carbonio-mailbox/pull/980))

### Files changed

- `systemd-envscript.sh` — removed `java.library.path` from java invocation and `java_library_path` from systemd.env output
- `java.sh` — removed `java.library.path` and `zimbra_zmjava_java_library_path` variable
- `javaext.sh` — removed `java.library.path` and `zimbra_zmjava_java_library_path` variable
- `mailboxdctl.sh` — removed `java.library.path`
- `playredo.sh` — removed `java.library.path`
- `localconfig.sh` — removed `java.library.path`
- `jsprecompile.sh` — removed `java.library.path`

## Test plan

- [ ] Verify `zmlocalconfig` works without `java.library.path`
- [ ] Verify `zmjava` wrapper runs correctly
- [ ] Verify mailbox starts via `mailboxdctl.sh` (legacy path)

Refs: CO-3493

🤖 Generated with [Claude Code](https://claude.com/claude-code)