### PR TITLE
ci(jenkins): migrate to jenkins-lib-common

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,14 @@
+library(
+    identifier: 'jenkins-lib-common@1.7.0',
+    retriever: modernSCM([
+        $class: 'GitSCMSource',
+        remote: 'git@github.com:zextras/jenkins-lib-common.git',
+        credentialsId: 'jenkins-integration-with-github-account'
+    ])
+)
+
+properties(defaultPipelineProperties())
+
 pipeline {
     options {
         skipDefaultCheckout()


### PR DESCRIPTION
Migrate Jenkinsfile to use jenkins-lib-common shared library, adding import, defaultPipelineProperties() per Zextras Jenkins standards.