### PR TITLE
fix(configd): connect to literal loopback IP instead of localhost

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-lib-common@v2.7.1',
+    identifier: 'jenkins-lib-common@v2.8.5',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         remote: 'git@github.com:zextras/jenkins-lib-common.git',

--- a/src/libexec/configd.py
+++ b/src/libexec/configd.py
@@ -119,10 +119,12 @@ def request_listener():
 	Log.logMsg(4, "Socket listener running as %s" % server_thread.getName())
 
 def contact_service(command, args=None):
-	listener_params = ("localhost",int(state.State.mState.localconfig["zmconfigd_listen_port"]))
+	port = int(state.State.mState.localconfig["zmconfigd_listen_port"])
 	if state.State.mState.serverconfig["zimbraIPMode"] == "ipv4":
+		listener_params = ("127.0.0.1", port)
 		sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 	else:
+		listener_params = ("::1", port)
 		sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
 	message = "%s " % command
 	if args:


### PR DESCRIPTION
contact_service() resolved 'localhost' via /etc/hosts, which fails or returns ::1 when the '127.0.0.1 localhost' entry is missing. Since request_listener() binds to 127.0.0.1 (ipv4) or ::1 (ipv6) directly, mirror the same address selection in contact_service() to avoid the hosts lookup entirely.

Refs: CO-3608