### PR TITLE
fix(CO-3594): make fresh-install LDAP bootstrap actually work

### DIFF
--- a/src/libexec/ldapinit.pm
+++ b/src/libexec/ldapinit.pm
@@ -134,78 +134,39 @@ sub postLdapStart {
   }
 
   $mesg = $ldap->bind( "cn=config", password => "$ldap_root_password" );
-
-  $infile = "$config_dir/carbonio.ldif";
-  $ldifin = Net::LDAP::LDIF->new( "$infile", "r", onerror => 'undef' );
-  while ( not $ldifin->eof() ) {
-    my $entry = $ldifin->read_entry();
-    if ( $ldifin->error() ) {
-      print "Error msg: ",    $ldifin->error(),       "\n";
-      print "Error lines:\n", $ldifin->error_lines(), "\n";
-      return 1;
-    } elsif ($entry) {
-      $entry->changetype("add");
-      $entry->update($ldap);
-    }
+  if ( $mesg->code ) {
+    print "ERROR: bind to cn=config failed: ", $mesg->error, "\n";
+    return 2;
   }
 
-  $infile = "$source_config_dir/zimbra/zimbra_globalconfig.ldif";
-  $ldifin = Net::LDAP::LDIF->new( "$infile", "r", onerror => 'undef' );
-  while ( not $ldifin->eof() ) {
-    my $entry = $ldifin->read_entry();
-    if ( $ldifin->error() ) {
-      print "Error msg: ",    $ldifin->error(),       "\n";
-      print "Error lines:\n", $ldifin->error_lines(), "\n";
-      return 1;
-    } elsif ($entry) {
-      $entry->changetype("add");
-      $entry->update($ldap);
-    }
-  }
+  my @ldif_files = (
+    "$config_dir/carbonio.ldif",
+    "$source_config_dir/zimbra/zimbra_globalconfig.ldif",
+    "$source_config_dir/zimbra/zimbra_defaultcos.ldif",
+    "$source_config_dir/zimbra/zimbra_defaultexternalcos.ldif",
+    ( -f "/opt/zextras/conf/ldap/mimehandlers.ldif"
+      ? "/opt/zextras/conf/ldap/mimehandlers.ldif"
+      : "$source_config_dir/zimbra/mimehandlers.ldif" ),
+  );
 
-  $infile = "$source_config_dir/zimbra/zimbra_defaultcos.ldif";
-  $ldifin = Net::LDAP::LDIF->new( "$infile", "r", onerror => 'undef' );
-  while ( not $ldifin->eof() ) {
-    my $entry = $ldifin->read_entry();
-    if ( $ldifin->error() ) {
-      print "Error msg: ",    $ldifin->error(),       "\n";
-      print "Error lines:\n", $ldifin->error_lines(), "\n";
-      return 1;
-    } elsif ($entry) {
-      $entry->changetype("add");
-      $entry->update($ldap);
-    }
-  }
-
-  $infile = "$source_config_dir/zimbra/zimbra_defaultexternalcos.ldif";
-  $ldifin = Net::LDAP::LDIF->new( "$infile", "r", onerror => 'undef' );
-  while ( not $ldifin->eof() ) {
-    my $entry = $ldifin->read_entry();
-    if ( $ldifin->error() ) {
-      print "Error msg: ",    $ldifin->error(),       "\n";
-      print "Error lines:\n", $ldifin->error_lines(), "\n";
-      return 1;
-    } elsif ($entry) {
-      $entry->changetype("add");
-      $entry->update($ldap);
-    }
-  }
-
-  if ( -f "/opt/zextras/conf/ldap/mimehandlers.ldif" ) {
-    $infile = "/opt/zextras/conf/ldap/mimehandlers.ldif";
-  } else {
-    $infile = "$source_config_dir/zimbra/mimehandlers.ldif";
-  }
-  $ldifin = Net::LDAP::LDIF->new( "$infile", "r", onerror => 'undef' );
-  while ( not $ldifin->eof() ) {
-    my $entry = $ldifin->read_entry();
-    if ( $ldifin->error() ) {
-      print "Error msg: ",    $ldifin->error(),       "\n";
-      print "Error lines:\n", $ldifin->error_lines(), "\n";
-      return 1;
-    } elsif ($entry) {
-      $entry->changetype("add");
-      $entry->update($ldap);
+  for my $f (@ldif_files) {
+    $infile = $f;
+    $ldifin = Net::LDAP::LDIF->new( "$infile", "r", onerror => 'undef' );
+    while ( not $ldifin->eof() ) {
+      my $entry = $ldifin->read_entry();
+      if ( $ldifin->error() ) {
+        print "Error msg: ",    $ldifin->error(),       "\n";
+        print "Error lines:\n", $ldifin->error_lines(), "\n";
+        return 1;
+      } elsif ($entry) {
+        $entry->changetype("add");
+        my $res = $entry->update($ldap);
+        if ( $res && $res->code ) {
+          print "ERROR: ldap add failed for ", $entry->dn(),
+                " (from $infile): ", $res->error, "\n";
+          return 2;
+        }
+      }
     }
   }
 
@@ -219,7 +180,8 @@ sub setLocalConfig {
   if ( exists $main::saved{lc}{$key} && $main::saved{lc}{$key} eq $val ) {
     return;
   }
-  $main::saved{lc}{$key} = $val;
+  $main::saved{lc}{$key}  = $val;
+  $main::loaded{lc}{$key} = $val;
   qx(su - zextras -c '/opt/zextras/bin/zmlocalconfig -f -e ${key}=\'${val}\' 2> /dev/null');
 }
 

--- a/src/libexec/setup.pl
+++ b/src/libexec/setup.pl
@@ -4651,6 +4651,19 @@ sub configSetupLdap {
 
     if ( !$ldapConfigured && isEnabled("carbonio-directory-server") && !-f "/opt/zextras/.enable_replica" && $newinstall && ( $config{LDAPHOST} eq $config{HOSTNAME} ) ) {
         progress("Initializing ldap...");
+        # Stop any already-running slapd BEFORE preLdapStart rewrites
+        # olcDatabase={0}config.ldif. Otherwise slapd keeps the stale
+        # olcRootPW in memory and the subsequent cn=config bind fails
+        # with rc=49 invalid credentials against an on-disk hash that
+        # is, in fact, correct. `systemctl start` / `ldap start` are
+        # no-ops on an already-active unit, so we cannot rely on them
+        # to reload the rewritten config.
+        if ( isSystemd() ) {
+            system("systemctl stop carbonio-openldap.service");
+        }
+        else {
+            runAsZextras("/opt/zextras/bin/ldap stop");
+        }
         ldapinit->preLdapStart( $config{LDAPROOTPASS}, $config{LDAPADMINPASS} );
         if ( isSystemd() ) {
             system("systemctl start carbonio-openldap.service");


### PR DESCRIPTION
Three independent bugs caused `Creating server entry...failed.` with LDAP rc=49 invalid credentials on a fresh install:

- **`ldapinit::setLocalConfig` cache desync.** It wrote to `%saved` but not to `%loaded`, so a later `getLocalConfig` kept returning the empty value that an earlier read had cached, and `preLdapStart` hashed that empty string into `olcRootPW`. Mirror `setup.pl::setLocalConfig` and update both hashes.
- **`ldapinit::postLdapStart` swallowed errors.** It ignored the return code of `$ldap->bind` and of every `$entry->update($ldap)`. Bootstrap printed `Initializing ldap...done.` while the bind and the LDIF loads were silently failing, and the error only surfaced later as a confusing `zmprov` stack trace. Check the bind result and each update result, return `2` with the failing DN/file/error. Collapse the four near-identical LDIF blocks into one loop.
- **slapd never reloaded the rewritten `olcRootPW`.** `configSetupLdap` called `preLdapStart` while slapd was already running (the unit auto-restarts at boot), then issued `systemctl start` / `ldap start` — both no-ops on an already-active service. slapd kept the stale `olcRootPW` in memory and rejected the bind against an on-disk hash that was, by that point, correct. Stop slapd before `preLdapStart` rewrites the config, in both the systemd and non-systemd branches.

## Verification

Reproduced the original failure in the Carbonio devel podman container, applied the patched files, reset and re-ran bootstrap from scratch — `Initializing ldap...done.` followed by a clean `Creating server entry...done.`.

Refs: CO-3594