### PR TITLE
fix(CO-3808): detect memcached started by sidecar in status check

### DIFF
--- a/src/bin/memcachedctl.sh
+++ b/src/bin/memcachedctl.sh
@@ -19,6 +19,15 @@ zmsetvars
 
 get_pid() {
   pid=$(pidof /opt/zextras/common/bin/memcached)
+  # Fallback: pidof resolves /proc/<pid>/exe, so when memcached is launched
+  # outside of this script (e.g. by carbonio-memcached-sidecar.service) through
+  # a symlinked or otherwise differently-resolved path, the exact-path match
+  # misses even though memcached is running. Match the command line of the
+  # zextras binary instead, which stays scoped to our instance (not a
+  # distro-packaged memcached) while tolerating the path difference.
+  if [ "$pid" = "" ]; then
+    pid=$(pgrep -f '/opt/zextras/common/bin/memcached')
+  fi
 }
 
 check_running() {


### PR DESCRIPTION
zmcontrol status reported memcached as Stopped after upgrade even though the process was running and serving on port 11211. get_pid relied solely on pidof, which resolves /proc/<pid>/exe against the absolute path /opt/zextras/common/bin/memcached. When memcached is launched outside of this script (e.g. by carbonio-memcached-sidecar.service) through a symlinked or differently-resolved path, that exact-path match misses and check_running set running=0.

Add a pgrep -f fallback matching the zextras binary command line. This stays scoped to our instance (not a distro-packaged memcached) while tolerating the path difference.