### PR TITLE
ci: update jenkins-lib-common to v2.11.2

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,25 @@
+{
+  "branches": ["main", "devel"],
+  "plugins": [
+    ["@semantic-release/commit-analyzer", {
+      "preset": "conventionalcommits",
+      "releaseRules": [
+        {"type": "refactor", "release": "patch"},
+        {"type": "chore", "release": false},
+        {"type": "ci", "release": false}
+      ]
+    }],
+    ["@semantic-release/release-notes-generator", {
+      "preset": "conventionalcommits"
+    }],
+    "@semantic-release/changelog",
+    ["@semantic-release/exec", {
+      "prepareCmd": "echo ${nextRelease.version} > VERSION"
+    }],
+    ["@semantic-release/git", {
+      "assets": ["CHANGELOG.md", "VERSION"],
+      "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
+    }],
+    "@semantic-release/github"
+  ]
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
         }
         stage('Skip CI') {
             steps {
-                script { semanticRelease.guard() }
+                semanticRelease.guard()
             }
         }
         stage('SonarQube analysis') {
@@ -46,7 +46,7 @@ pipeline {
         }
         stage('Semantic Release') {
             steps {
-                script { semanticRelease() }
+                semanticRelease()
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
         }
         stage('Skip CI') {
             steps {
-                semanticRelease.guard()
+                script { semanticRelease.guard() }
             }
         }
         stage('SonarQube analysis') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
         stage('Checkout') {
             steps {
                 checkout scm
-                stash includes: '**', name: 'staging'
+                gitMetadata()
             }
         }
         stage('Skip CI') {
@@ -35,7 +35,6 @@ pipeline {
         }
         stage('SonarQube analysis') {
             steps {
-                unstash 'staging'
                 script {
                     scannerHome = tool 'SonarScanner';
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-lib-common@v2.8.5',
+    identifier: 'jenkins-lib-common@v2.11.2',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         remote: 'git@github.com:zextras/jenkins-lib-common.git',
@@ -27,6 +27,11 @@ pipeline {
                 stash includes: '**', name: 'staging'
             }
         }
+        stage('Skip CI') {
+            steps {
+                script { semanticRelease.guard() }
+            }
+        }
         stage('SonarQube analysis') {
             steps {
                 unstash 'staging'
@@ -37,6 +42,11 @@ pipeline {
                     installationName: 'SonarQube instance') {
                     sh "${scannerHome}/bin/sonar-scanner"
                 }
+            }
+        }
+        stage('Semantic Release') {
+            steps {
+                script { semanticRelease() }
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,8 +11,9 @@ properties(defaultPipelineProperties())
 
 pipeline {
     options {
-        skipDefaultCheckout()
         buildDiscarder(logRotator(numToKeepStr: '5'))
+        disableConcurrentBuilds()
+        skipDefaultCheckout()
         timeout(time: 1, unit: 'HOURS')
     }
     agent {


### PR DESCRIPTION
## Summary
- Bump `jenkins-lib-common` to `v2.11.2`
- Add `semanticRelease.guard()` Skip CI stage and `semanticRelease()` release stage
- Add `.releaserc.json` with standard Zextras configuration

## Checklist
- [x] Library version bumped to v2.11.2
- [x] No `packages:` in uploadStage calls
- [x] No `uploadStage.shouldUpload()` when-guard
- [x] No `dt2_semanticRelease()`
- [x] Semantic release configured