### PR TITLE
fix(ci): remove @semantic-release/exec from .releaserc.json

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -13,11 +13,8 @@
       "preset": "conventionalcommits"
     }],
     "@semantic-release/changelog",
-    ["@semantic-release/exec", {
-      "prepareCmd": "echo ${nextRelease.version} > VERSION"
-    }],
     ["@semantic-release/git", {
-      "assets": ["CHANGELOG.md", "VERSION"],
+      "assets": ["CHANGELOG.md"],
       "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
     }],
     "@semantic-release/github"


### PR DESCRIPTION
Remove the `@semantic-release/exec` plugin and `VERSION` file generation that were mistakenly added. Also remove `VERSION` from the git assets list.