### PR TITLE
fix(mta): use Postfix 3.11 parameter names and set compatibility_level

### DIFF
--- a/conf/configd.cf
+++ b/conf/configd.cf
@@ -121,6 +121,7 @@ SECTION mta DEPENDS amavis
 	POSTCONF message_size_limit			VAR zimbraMtaMaxMessageSize
 	POSTCONF mailbox_size_limit			0
 	POSTCONF smtputf8_enable			no
+	POSTCONF compatibility_level			3.11
 	POSTCONF max_use				VAR zimbraMtaMaxUse
 	POSTCONF relayhost				VAR zimbraMtaRelayHost
 	POSTCONF smtp_dns_support_level			VAR zimbraMtaSmtpDnsSupportLevel
@@ -213,7 +214,6 @@ SECTION mta DEPENDS amavis
 	POSTCONF smtpd_sasl_tls_security_options	VAR zimbraMtaSmtpdSaslTlsSecurityOptions
 	POSTCONF smtpd_client_auth_rate_limit		VAR zimbraMtaSmtpdClientAuthRateLimit
 	POSTCONF smtp_helo_name				VAR zimbraMtaSmtpHeloName
-	POSTCONF smtp_cname_overrides_servername	VAR zimbraMtaSmtpCnameOverridesServername
 	POSTCONF smtp_sasl_auth_enable			VAR zimbraMtaSmtpSaslAuthEnable
 	POSTCONF smtp_sasl_security_options		VAR zimbraMtaSmtpSaslSecurityOptions
 	POSTCONF smtp_tls_CAfile			VAR zimbraMtaSmtpTlsCAfile
@@ -243,7 +243,7 @@ SECTION mta DEPENDS amavis
 	POSTCONF postscreen_bare_newline_action	VAR zimbraMtaPostscreenBareNewlineAction
 	POSTCONF postscreen_bare_newline_enable	VAR zimbraMtaPostscreenBareNewlineEnable
 	POSTCONF postscreen_bare_newline_ttl	VAR zimbraMtaPostscreenBareNewlineTTL
-	POSTCONF postscreen_blacklist_action	VAR zimbraMtaPostscreenBlacklistAction
+	POSTCONF postscreen_denylist_action	VAR zimbraMtaPostscreenBlacklistAction
 	POSTCONF postscreen_cache_cleanup_interval	VAR zimbraMtaPostscreenCacheCleanupInterval
 	POSTCONF postscreen_cache_retention_time	VAR zimbraMtaPostscreenCacheRetentionTime
 	POSTCONF postscreen_command_count_limit	VAR zimbraMtaPostscreenCommandCountLimit
@@ -251,10 +251,9 @@ SECTION mta DEPENDS amavis
 	POSTCONF postscreen_dnsbl_reply_map		VAR zimbraMtaPostscreenDnsblReplyMap
 	POSTCONF postscreen_dnsbl_sites			VAR zimbraMtaPostscreenDnsblSites
 	POSTCONF postscreen_dnsbl_threshold		VAR zimbraMtaPostscreenDnsblThreshold
-	POSTCONF postscreen_dnsbl_ttl			VAR zimbraMtaPostscreenDnsblTTL
 	POSTCONF postscreen_dnsbl_max_ttl		VAR zimbraMtaPostscreenDnsblMaxTTL
 	POSTCONF postscreen_dnsbl_min_ttl		VAR zimbraMtaPostscreenDnsblMinTTL
-	POSTCONF postscreen_dnsbl_whitelist_threshold	VAR zimbraMtaPostscreenDnsblWhitelistThreshold
+	POSTCONF postscreen_dnsbl_allowlist_threshold	VAR zimbraMtaPostscreenDnsblWhitelistThreshold
 	POSTCONF postscreen_greet_action		VAR zimbraMtaPostscreenGreetAction
 	POSTCONF postscreen_greet_ttl			VAR zimbraMtaPostscreenGreetTTL
 	POSTCONF postscreen_non_smtp_command_action	VAR zimbraMtaPostscreenNonSmtpCommandAction
@@ -265,7 +264,7 @@ SECTION mta DEPENDS amavis
 	POSTCONF postscreen_pipelining_ttl		VAR zimbraMtaPostscreenPipeliningTTL
 	POSTCONF postscreen_upstream_proxy_protocol	VAR zimbraMtaPostscreenUpstreamProxyProtocol
 	POSTCONF postscreen_watchdog_timeout	VAR zimbraMtaPostscreenWatchdogTimeout
-	POSTCONF postscreen_whitelist_interfaces	VAR zimbraMtaPostscreenWhitelistInterfaces
+	POSTCONF postscreen_allowlist_interfaces	VAR zimbraMtaPostscreenWhitelistInterfaces
 	POSTCONF smtp_starttls_timeout                  LOCAL postfix_smtp_starttls_timeout
 	POSTCONF tls_random_source                      LOCAL postfix_tls_random_source
 	POSTCONF tls_eecdh_strong_curve                 LOCAL postfix_tls_eecdh_strong_curve


### PR DESCRIPTION
## Summary

Postfix 3.11 (built in `carbonio-thirds`, branch CO-3843) deprecates several `postscreen`/`smtp` parameter names and logs warnings about using *backwards-compatible default settings*. The runtime `/opt/zextras/common/conf/main.cf` is authored by `zmconfigd` from this `conf/configd.cf` template, which still emits the pre-3.6 names. This updates them to the current names so the warnings disappear.

### Warnings being fixed
```
postfix: Postfix is using backwards-compatible default settings
postconf: warning: ... "postscreen_blacklist_action" will be removed; instead, specify "postscreen_denylist_action"
postconf: warning: ... "postscreen_dnsbl_ttl" will be removed; instead, specify "postscreen_dnsbl_max_ttl"
postconf: warning: ... "postscreen_dnsbl_whitelist_threshold" will be removed; instead, specify "postscreen_dnsbl_allowlist_threshold"
postconf: warning: ... "postscreen_whitelist_interfaces" will be removed; instead, specify "postscreen_allowlist_interfaces"
postconf: warning: ... "smtp_cname_overrides_servername" will be removed; instead, do not specify
```

## Changes (`conf/configd.cf`, `SECTION mta`)

| Old | New |
|---|---|
| `postscreen_blacklist_action` | `postscreen_denylist_action` |
| `postscreen_dnsbl_whitelist_threshold` | `postscreen_dnsbl_allowlist_threshold` |
| `postscreen_whitelist_interfaces` | `postscreen_allowlist_interfaces` |
| `postscreen_dnsbl_ttl` | **removed** — superseded by `postscreen_dnsbl_min_ttl` / `postscreen_dnsbl_max_ttl` already present |
| `smtp_cname_overrides_servername` | **removed** — Postfix: *"instead, do not specify"* |
| *(absent)* | `compatibility_level = 3.11` added |

## Notes
- Only the left-hand Postfix parameter names change; the `zimbra*` LDAP attributes are untouched, so existing admin-configured values are preserved (no schema migration).
- `postscreen_dnsbl_ttl` was split into min/max TTL in Postfix 3.6; both are already mapped in this template, making the legacy line redundant. `zimbraMtaPostscreenDnsblTTL` simply becomes unused.
- `smtp_cname_overrides_servername`'s non-default behavior is being dropped upstream, so leaving it unset is the intended end state.

Related: CO-3843 (Postfix 3.11.3 update in `carbonio-thirds`).